### PR TITLE
Replace deprecated calls

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(${CMAKE_BINARY_DIR}/src)
 include_directories(${CMAKE_SOURCE_DIR}/tests/src)
-include_directories(${CMAKE_SOURCE_DIR}/build/src)
 include_directories(${BML_INCLUDEDIR})
 
 function(progress_example myexample path_to_example)

--- a/src/latte_mods/ham_latte_mod.F90
+++ b/src/latte_mods/ham_latte_mod.F90
@@ -168,8 +168,8 @@ contains
    !$omp end parallel do
 
 !     bml_type=bml_get_type(ham_bml) !Get the bml type
-!     call bml_convert_from_dense(bml_type,over,over_bml,threshold,norb) !Dense to dense_bml
-!     call bml_convert_from_dense(bml_type,ham,ham_bml,threshold,norb) !Dense to dense_bml
+!     call bml_import_from_dense(bml_type,over,over_bml,threshold,norb) !Dense to dense_bml
+!     call bml_import_from_dense(bml_type,ham,ham_bml,threshold,norb) !Dense to dense_bml
 
 !     call bml_print_matrix("ham_bml",ham_bml,0,6,0,6)
 !     call bml_print_matrix("over_bml",over_bml,0,6,0,6)

--- a/src/prg_densitymatrix_mod.F90
+++ b/src/prg_densitymatrix_mod.F90
@@ -361,9 +361,9 @@ contains
     !Ensure dense type to diagonalize
     if(trim(bml_type).ne."dense")then
       allocate(aux(norb,norb))
-      call bml_convert_to_dense(ham_bml,aux)
+      call bml_export_to_dense(ham_bml,aux)
       call bml_zero_matrix(bml_matrix_dense,bml_element_real,dp,norb,norb,aux_bml)
-      call bml_convert_from_dense(bml_matrix_dense,aux,aux_bml,0.0_dp,norb)
+      call bml_import_from_dense(bml_matrix_dense,aux,aux_bml,0.0_dp,norb)
       deallocate(aux)
     else
       call bml_copy_new(ham_bml,aux_bml)

--- a/src/prg_genz_mod.F90
+++ b/src/prg_genz_mod.F90
@@ -320,11 +320,11 @@ contains
     !To bml dense. this is done because the diagonalization
     !it is only implemented for bml_dense. In future versions of bml
     !the api should do this automatically.
-    call bml_convert_to_dense(smat_bml, smat) !my_bml_type to dense
+    call bml_export_to_dense(smat_bml, smat) !my_bml_type to dense
 
     call bml_zero_matrix(BML_MATRIX_DENSE,bml_element_real,dp, norb,norb,saux_bml) !Allocate bml dense
 
-    call bml_convert_from_dense(BML_MATRIX_DENSE,smat,saux_bml,threshold,mdim) !Dense to dense_bml
+    call bml_import_from_dense(BML_MATRIX_DENSE,smat,saux_bml,threshold,mdim) !Dense to dense_bml
 
 !     call bml_print_matrix("Smat_bml",smat_bml,0,6,0,6)
 !     call bml_print_matrix("Smat",saux_bml,0,6,0,6)
@@ -343,7 +343,7 @@ contains
     call bml_diagonalize(saux_bml,nono_evals,umat_bml)
     write(*,*)"Time for S diag = "//to_string(mls() - mls_i)//" ms"
 
-    call bml_convert_to_dense(umat_bml, umat)
+    call bml_export_to_dense(umat_bml, umat)
 
     nonotmp=0.0_dp
 
@@ -370,7 +370,7 @@ contains
 !     endif
 ! #endif
 
-    call bml_convert_from_dense(BML_MATRIX_DENSE, nonotmp, nonotmp_bml)
+    call bml_import_from_dense(BML_MATRIX_DENSE, nonotmp, nonotmp_bml)
 
     !Doing u s^-1/2 u^t
     !!call bml_multiply(nonotmp_bml,umat_t_bml, zmat_bml, 1.0_dp, 1.0_dp,threshold)
@@ -379,16 +379,16 @@ contains
     !If the original type was ellpack then we convert back from
     !dense to ellpack. This is done just to be able to test ellpack with sp2 and buildzdiag.
     if(bml_type.eq."ellpack")then
-      call bml_convert_to_dense(zmat_bml, zmat)!Dense_bml to dense.
+      call bml_export_to_dense(zmat_bml, zmat)!Dense_bml to dense.
       call bml_deallocate(zmat_bml)
 !       call bml_zero_matrix(bml_matrix_ellpack,bml_element_real,dp, norb,norb,zmat_bml) !Reallocate in ellpack.
-!       call bml_convert_from_dense(bml_matrix_ellpack,zmat,zmat_bml,threshold,mdim) !Dense to ellpack_bml.
-       call bml_convert_from_dense(bml_matrix_ellpack,zmat,zmat_bml,threshold,mdim, bml_get_distribution_mode(smat_bml)) !Dense to ellpack_bml.
+!       call bml_import_from_dense(bml_matrix_ellpack,zmat,zmat_bml,threshold,mdim) !Dense to ellpack_bml.
+       call bml_import_from_dense(bml_matrix_ellpack,zmat,zmat_bml,threshold,mdim, bml_get_distribution_mode(smat_bml)) !Dense to ellpack_bml.
     endif
 
     !     !To check for the accuracy of the approximation (prg_delta). this is done using matmul
     !     !so its very inefficient. Only uncomment for debugging purpose.
-!           call bml_convert_to_dense(zmat_bml, zmat)
+!           call bml_export_to_dense(zmat_bml, zmat)
 !           call prg_delta(zmat,smat,norb,err_check)
 !           write(*,*)"err", err_check, norb
 !            stop
@@ -465,7 +465,7 @@ contains
     call prg_genz_sp_ref(smat_bml,zmat_bml,nref,mdim,bml_type,threshold)
     if(verbose.EQ.1)write(*,*)"Time for prg_genz_sp_ref "//to_string(mls()-sec_i)//" ms"
 
-    !     call bml_convert_to_dense()
+    !     call bml_export_to_dense()
     !     call prg_delta(xmat,smat,norb,err_check)  !to check for the accuracy of the approximation (prg_delta)
     !     write(*,*)"err", err_check, norb
     !     stop
@@ -503,13 +503,13 @@ contains
     allocate(sthres(norb,norb))
 
     allocate(smat(norb,norb))
-    call bml_convert_to_dense(smat_bml,smat)
+    call bml_export_to_dense(smat_bml,smat)
 
     call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,sthres_bml) !a thresholded version of s
 
-    call bml_convert_from_dense(bml_type,smat,sthres_bml,thresholdZ0,mdim)
+    call bml_import_from_dense(bml_type,smat,sthres_bml,thresholdZ0,mdim)
 
-    call bml_convert_to_dense(sthres_bml,sthres) !We will use the dense to extract the small blocks.
+    call bml_export_to_dense(sthres_bml,sthres) !We will use the dense to extract the small blocks.
 
     allocate(kk(norb)) !The nonzero positions in the row
 
@@ -549,9 +549,9 @@ contains
         end do
       end do
 
-      call bml_convert_from_dense(bml_type, stmp, stmp_bml)
+      call bml_import_from_dense(bml_type, stmp, stmp_bml)
       call bml_diagonalize(stmp_bml,stmp_evals,utmp_bml)
-      call bml_convert_to_dense(utmp_bml,utmp)
+      call bml_export_to_dense(utmp_bml,utmp)
 
       do j = 1, k  !Applying the inverse sqrt function to the eigenvalues.
         invsqrt = 1.0_dp/sqrt(stmp_evals(j))
@@ -562,10 +562,10 @@ contains
 
       utmp=transpose(utmp)
 
-      call bml_convert_from_dense(bml_type , utmp , utmp_bml)
-      call bml_convert_from_dense(bml_type, sitmp, sitmp_bml)
+      call bml_import_from_dense(bml_type , utmp , utmp_bml)
+      call bml_import_from_dense(bml_type, sitmp, sitmp_bml)
       call bml_multiply(sitmp_bml,utmp_bml,xtmp_bml,1.0_dp,0.0_dp)
-      call bml_convert_to_dense(xtmp_bml,ztmp)
+      call bml_export_to_dense(xtmp_bml,ztmp)
 
       do l = 1, k  !Reconstructing the large Z0 based in the small Z.
         do j = 1, k
@@ -586,7 +586,7 @@ contains
     end do
 
     call bml_zero_matrix(bml_type_f,bml_element_real,dp,norb,norb,zmat_bml)
-    call bml_convert_from_dense(bml_type_f,zmat, zmat_bml,threshold,mdim) !Converting to bml format
+    call bml_import_from_dense(bml_type_f,zmat, zmat_bml,threshold,mdim) !Converting to bml format
 
         ! call prg_delta(zmat,smat,norb,err_check)  !to check for the accuracy of the approximation (prg_delta)
         ! call sparsity(smat,norb,spa)
@@ -630,16 +630,16 @@ contains
     allocate(sthres(norb,norb))
 
     allocate(smat(norb,norb))
-    call bml_convert_to_dense(smat_bml,smat)
+    call bml_export_to_dense(smat_bml,smat)
 
     ! a thresholded version of s
     call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,sthres_bml)
 
-    !call bml_convert_from_dense(bml_type,smat,sthres_bml,thresholdZ0,mdim)
-    call bml_convert_from_dense(bml_type,smat,sthres_bml,threshold,mdim)
+    !call bml_import_from_dense(bml_type,smat,sthres_bml,thresholdZ0,mdim)
+    call bml_import_from_dense(bml_type,smat,sthres_bml,threshold,mdim)
 
     ! We will use the dense to extract the small blocks.
-    call bml_convert_to_dense(sthres_bml,sthres)
+    call bml_export_to_dense(sthres_bml,sthres)
 
     allocate(kk(norb)) !The nonzero positions in the row
 
@@ -684,9 +684,9 @@ contains
         end do
       end do
 
-      call bml_convert_from_dense(BML_MATRIX_DENSE, stmp, stmp_bml)
+      call bml_import_from_dense(BML_MATRIX_DENSE, stmp, stmp_bml)
       call bml_diagonalize(stmp_bml,stmp_evals,utmp_bml)
-      call bml_convert_to_dense(utmp_bml,utmp)
+      call bml_export_to_dense(utmp_bml,utmp)
 
       do j = 1, k  !Applying the inverse sqrt function to the eigenvalues.
         invsqrt = 1.0_dp/sqrt(stmp_evals(j))
@@ -697,10 +697,10 @@ contains
 
       utmp=transpose(utmp)
 
-      call bml_convert_from_dense(bml_type, utmp, utmp_bml)
-      call bml_convert_from_dense(bml_type, sitmp, sitmp_bml)
+      call bml_import_from_dense(bml_type, utmp, utmp_bml)
+      call bml_import_from_dense(bml_type, sitmp, sitmp_bml)
       call bml_multiply(sitmp_bml,utmp_bml,xtmp_bml,1.0_dp,0.0_dp)
-      call bml_convert_to_dense(xtmp_bml,ztmp)
+      call bml_export_to_dense(xtmp_bml,ztmp)
 
       do l = 1, k  !Reconstructing the large Z0 based in the small Z.
         do j = 1, k
@@ -722,7 +722,7 @@ contains
     end do
 
     !call bml_zero_matrix(bml_type_f,bml_element_real,dp,norb,norb,zmat_bml)
-    call bml_convert_from_dense(bml_type_f,zmat,zmat_bml,threshold,mdim, &
+    call bml_import_from_dense(bml_type_f,zmat,zmat_bml,threshold,mdim, &
       bml_get_distribution_mode(smat_bml))
 !Converting to bml format
 
@@ -880,8 +880,8 @@ contains
       ! call bml_scale(0.0_dp,temp1_bml)
       ! call bml_scale(0.0_dp,temp2_bml)
 
-      ! call bml_convert_to_dense(zmat_bml,zmat)
-      ! call bml_convert_to_dense(smat_bml,smat)
+      ! call bml_export_to_dense(zmat_bml,zmat)
+      ! call bml_export_to_dense(smat_bml,smat)
             ! call prg_delta(zmat,smat,norb,err_check)  !to check for the accuracy of the approximation (prg_delta)
             ! call sparsity(smat,norb,spa)
             ! write(*,*)"err", err_check, threshold

--- a/src/prg_quantumdynamics_mod.F90
+++ b/src/prg_quantumdynamics_mod.F90
@@ -65,11 +65,11 @@ contains
     call bml_set_diagonal(T1,tmat1,thresh)
     deallocate (tmat1)
     call bml_zero_matrix(bmltype, BML_ELEMENT_COMPLEX,dp,N,N, rho_bml)
-    call bml_convert_from_dense(bmltype,dens,rho_bml,thresh,N)
+    call bml_import_from_dense(bmltype,dens,rho_bml,thresh,N)
     call bml_zero_matrix(bmltype, BML_ELEMENT_COMPLEX,dp,N,N, T2)
     call bml_multiply(T1,rho_bml,T2)
     call bml_zero_matrix(bmltype, BML_ELEMENT_COMPLEX,dp,N,N, s_bml)
-    call bml_convert_from_dense(bmltype,S,s_bml,thresh,N)
+    call bml_import_from_dense(bmltype,S,s_bml,thresh,N)
     call bml_multiply(T2,s_bml,rho_bml)
     call bml_deallocate(s_bml)
     
@@ -78,12 +78,12 @@ contains
     call bml_multiply(rho_bml,T1,T2)
     call bml_deallocate(T1)
     call bml_zero_matrix(bmltype, BML_ELEMENT_COMPLEX,dp,N,N, sinv_bml)
-    call bml_convert_from_dense(bmltype,SINV,sinv_bml,thresh,N)
+    call bml_import_from_dense(bmltype,SINV,sinv_bml,thresh,N)
     call bml_multiply(T2,sinv_bml,rho_bml)
     call bml_deallocate(sinv_bml)
     call bml_deallocate(T2)
 
-    call bml_convert_to_dense(rho_bml,dens)
+    call bml_export_to_dense(rho_bml,dens)
 
   end subroutine prg_kick_density
 
@@ -111,12 +111,12 @@ contains
     call bml_zero_matrix(BML_MATRIX_DENSE, BML_ELEMENT_COMPLEX,dp,N,N, C1)
 
     !Transform matricies into bml and do computation
-    call bml_convert_from_dense(BML_MATRIX_DENSE,A,A1,thresh,N)
-    call bml_convert_from_dense(BML_MATRIX_DENSE,B,B1,thresh,N)
+    call bml_import_from_dense(BML_MATRIX_DENSE,A,A1,thresh,N)
+    call bml_import_from_dense(BML_MATRIX_DENSE,B,B1,thresh,N)
 
     call bml_multiply(A1,B1,C1)
     call bml_multiply(B1,A1,C1,-1.0d0,1.0d0)
-    call bml_convert_to_dense(C1,C)
+    call bml_export_to_dense(C1,C)
 
     call bml_deallocate(A1)
     call bml_deallocate(B1)
@@ -148,7 +148,7 @@ contains
     asize=SIZE(a_dense,1)
     convert_threshold=1.0d-5
     call bml_zero_matrix(matrix_type, element_type,dp,asize,asize, a)
-    call bml_convert_from_dense(matrix_type, a_dense, a, convert_threshold,asize)
+    call bml_import_from_dense(matrix_type, a_dense, a, convert_threshold,asize)
     !write(*,*)"thr,sparsity ",sparsity_threshold, bml_get_sparsity(a, sparsity_threshold)
 
     call bml_deallocate(a)
@@ -177,7 +177,7 @@ contains
     asize=SIZE(a_dense,1)
     convert_threshold=1.0d-5
     call bml_zero_matrix(matrix_type, element_type,dp,asize,asize, a)
-    call bml_convert_from_dense(matrix_type,a_dense,a,convert_threshold,asize)
+    call bml_import_from_dense(matrix_type,a_dense,a,convert_threshold,asize)
     !write(*,*)"thr,sparsity ", sparsity_threshold,bml_get_sparsity(a,sparsity_threshold)
 
     call bml_deallocate(a)
@@ -335,7 +335,7 @@ contains
 
     dR = 2.0_dp*dt*cmplx(0.0_dp,-1.0_dp/hbar)
     call prg_commutate_bml(H,rho_cur,aux_bml)
-    call bml_scale_cmplx(dR,aux_bml)
+    call bml_scale(dR,aux_bml)
     call bml_add(aux_bml,rho_old,1.0d0,1.0d0)
     call bml_copy(rho_cur,rho_old)
     call bml_copy(aux_bml,rho_cur)
@@ -406,11 +406,11 @@ contains
 
     allocate(diag(N))
     call bml_zero_matrix(bmltype,BML_ELEMENT_COMPLEX,dp,N,N,rho_bml)
-    call bml_convert_from_dense(bmltype,rho,rho_bml,thresh,N)
+    call bml_import_from_dense(bmltype,rho,rho_bml,thresh,N)
     call bml_zero_matrix(bmltype,BML_ELEMENT_COMPLEX,dp,N,N,rhoold_bml)
-    call bml_convert_from_dense(bmltype,rhoold,rhoold_bml,thresh,N)
+    call bml_import_from_dense(bmltype,rhoold,rhoold_bml,thresh,N)
     call bml_zero_matrix(bmltype,BML_ELEMENT_COMPLEX,dp,N,N,h1_bml)
-    call bml_convert_from_dense(bmltype,h1,h1_bml,thresh,N)
+    call bml_import_from_dense(bmltype,h1,h1_bml,thresh,N)
     call bml_zero_matrix(bmltype,BML_ELEMENT_COMPLEX,dp,N,N,aux)
 
   end subroutine prg_allocate_bml

--- a/src/prg_response_mod.F90
+++ b/src/prg_response_mod.F90
@@ -268,9 +268,9 @@ contains
 
     !Ensure dense type to diagonalize
     allocate(aux(norb,norb))
-    call bml_convert_to_dense(ham_bml,aux)
+    call bml_export_to_dense(ham_bml,aux)
     call bml_zero_matrix(bml_matrix_dense,bml_element_real,dp,norb,norb,aux_bml)
-    call bml_convert_from_dense(bml_matrix_dense,aux,aux_bml,threshold,norb)
+    call bml_import_from_dense(bml_matrix_dense,aux,aux_bml,threshold,norb)
     deallocate(aux)
 
     call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,umat_bml)
@@ -281,10 +281,10 @@ contains
 
     !Ensure the umat type is in bml_type.
     allocate(aux(norb,norb))
-    call bml_convert_to_dense(umat_bml,aux)
+    call bml_export_to_dense(umat_bml,aux)
     call bml_deallocate(umat_bml)
     call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,umat_bml)
-    call bml_convert_from_dense(bml_type,aux,umat_bml,threshold,norb)
+    call bml_import_from_dense(bml_type,aux,umat_bml,threshold,norb)
     deallocate(aux)
 
     call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,aux_bml)

--- a/tests/src/main.F90
+++ b/tests/src/main.F90
@@ -90,7 +90,7 @@ program main
   bndfil = 0.666666666666666666_dp !Filing factor for water box systems
 
   !Convert the Hamiltonian to bml
-  call bml_convert_from_dense(bml_type,ham,ham_bml,threshold,norb)
+  call bml_import_from_dense(bml_type,ham,ham_bml,threshold,norb)
 
   !Allocate the density matrix
   call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,rho_bml)
@@ -170,7 +170,7 @@ program main
     call prg_timer_start(loop_timer)
 
     bml_type = "dense"
-    call bml_convert_from_dense(bml_type,ham,ham_bml,threshold,norb)
+    call bml_import_from_dense(bml_type,ham,ham_bml,threshold,norb)
     call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,rho_bml)
 
     call prg_timer_start(sp2_timer)
@@ -192,7 +192,7 @@ program main
     call prg_timer_start(loop_timer)
 
     bml_type = "dense"
-    call bml_convert_from_dense(bml_type,ham,ham_bml,threshold,norb)
+    call bml_import_from_dense(bml_type,ham,ham_bml,threshold,norb)
     call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,rho_bml)
 
     call prg_timer_start(sp2_timer)
@@ -304,7 +304,7 @@ program main
     call prg_timer_start(loop_timer)
 
     bml_type = "dense"
-    call bml_convert_from_dense(bml_type,ham,ham_bml,threshold,norb)
+    call bml_import_from_dense(bml_type,ham,ham_bml,threshold,norb)
     call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,rho_bml)
 
     allocate(pp(100),vv(100))
@@ -334,7 +334,7 @@ program main
     call prg_timer_start(loop_timer)
 
     bml_type = "dense"
-    call bml_convert_from_dense(bml_type,ham,ham_bml,threshold,norb)
+    call bml_import_from_dense(bml_type,ham,ham_bml,threshold,norb)
     call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,rho_bml)
 
     allocate(pp(100),vv(100))
@@ -440,7 +440,7 @@ program main
     call prg_timer_start(loop_timer)
 
     bml_type = "dense"
-    call bml_convert_from_dense(bml_type,ham,ham_bml,threshold,norb)
+    call bml_import_from_dense(bml_type,ham,ham_bml,threshold,norb)
     call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,rho_bml)
 
     allocate(pp(100),vv(100), gbnd(2))
@@ -476,7 +476,7 @@ program main
     call prg_timer_start(loop_timer)
 
     bml_type = "dense"
-    call bml_convert_from_dense(bml_type,ham,ham_bml,threshold,norb)
+    call bml_import_from_dense(bml_type,ham,ham_bml,threshold,norb)
     call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,rho_bml)
 
     allocate(pp(100),vv(100), gbnd(2))
@@ -685,13 +685,13 @@ program main
      call read_matrix(rho_ortho,norb,'density_ortho.mtx')
 
      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,rho_bml)
-     call bml_convert_from_dense(bml_type,rho,rho_bml,threshold,norb)
+     call bml_import_from_dense(bml_type,rho,rho_bml,threshold,norb)
 
      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,rho_ortho_bml)
-     call bml_convert_from_dense(bml_type,rho_ortho,rho_ortho_bml,threshold,norb)
+     call bml_import_from_dense(bml_type,rho_ortho,rho_ortho_bml,threshold,norb)
 
      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,zmat_bml)
-     call bml_convert_from_dense(bml_type,zmat,zmat_bml,threshold,norb)
+     call bml_import_from_dense(bml_type,zmat,zmat_bml,threshold,norb)
 
      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,aux_bml)
 
@@ -725,16 +725,16 @@ program main
      call read_matrix(zmat,norb,'zmatrix.mtx')
      call read_matrix(nonortho_ham,norb,'hamiltonian.mtx')
 
-     call bml_convert_from_dense(bml_type,ham,ham_bml,threshold,norb)
+     call bml_import_from_dense(bml_type,ham,ham_bml,threshold,norb)
      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,rho_bml)
 
      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,zmat_bml)
-     call bml_convert_from_dense(bml_type,zmat,zmat_bml,threshold,norb)
+     call bml_import_from_dense(bml_type,zmat,zmat_bml,threshold,norb)
 
      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,nonortho_ham_bml)
 
      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,aux_bml)
-     call bml_convert_from_dense(bml_type,nonortho_ham,nonortho_ham_bml,threshold,norb)
+     call bml_import_from_dense(bml_type,nonortho_ham,nonortho_ham_bml,threshold,norb)
 
      call prg_timer_start(ortho_timer)
      call prg_orthogonalize(nonortho_ham_bml,zmat_bml,aux_bml,threshold,bml_type,verbose)
@@ -768,10 +768,10 @@ program main
      call read_matrix(over,norb,'overlap.mtx')
 
      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,zmat_bml)
-     call bml_convert_from_dense(bml_type,zmat,zmat_bml,threshold,norb)
+     call bml_import_from_dense(bml_type,zmat,zmat_bml,threshold,norb)
 
      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,over_bml)
-     call bml_convert_from_dense(bml_type,over,over_bml,threshold,norb)
+     call bml_import_from_dense(bml_type,over,over_bml,threshold,norb)
 
      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,aux_bml)
 !


### PR DESCRIPTION
Upstream bml has deprecated the `bml_convert_to_dense` and
`bml_convert_from_dense` APIs in favor of `bml_import_from_dense` and
`bml_export_to_dense`. This changes updates the progress library to use
the new function names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/qmd-progress/84)
<!-- Reviewable:end -->
