### PR TITLE
Remove unnecessary `BLAS_VENDOR` flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,12 +74,9 @@ endif()
 
 include(FindPkgConfig)
 
-pkg_check_modules(BML bml REQUIRED)
+pkg_check_modules(BML REQUIRED bml)
 message(STATUS "Found bml: ${BML_LDFLAGS}")
 list(APPEND LINK_LIBRARIES ${BML_LDFLAGS})
-
-set(BLAS_VENDOR ""
-  CACHE STRING "If set, the preferred BLAS/LAPACK vendor. Possible choices: {Intel,MKL,ACML}")
 
 set(PROGRESS_GRAPHLIB FALSE CACHE BOOL "Compile with externel graph libraries")
 if(PROGRESS_GRAPHLIB)

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,6 @@ EOF
     echo "PROGRESS_EXAMPLES  {yes,no}                 (default is ${PROGRESS_EXAMPLES})"
     echo "PROGRESS_GRAPHLIB  {yes,no}                 (default is ${PROGRESS_GRAPHLIB})"
     echo "BUILD_DIR          Path to build dir        (default is ${BUILD_DIR})"
-    echo "BLAS_VENDOR        {,Intel,MKL,ACML}        (default is '${BLAS_VENDOR}')"
     echo "INSTALL_DIR        Path to install dir      (default is ${INSTALL_DIR})"
     echo "EXTRA_FCFLAGS      Extra fortran flags      (default is '${EXTRA_FCFLAGS}')"
     echo "EXTRA_LINK_FLAGS   Any extra link flag      (default is '${EXTRA_LINK_FLAGS}')"
@@ -58,7 +57,6 @@ set_defaults() {
     : ${PROGRESS_TESTING:=no}
     : ${PROGRESS_EXAMPLES:=no}
     : ${PROGRESS_GRAPHLIB:=no}
-    : "${BLAS_VENDOR:=}"
     : "${EXTRA_FCFLAGS:=}"
     : ${EXTRA_LINK_FLAGS:=""}
     : ${SANITY_CHECK:=no}
@@ -118,7 +116,6 @@ configure() {
         -DPROGRESS_TESTING="${PROGRESS_TESTING}" \
         -DPROGRESS_EXAMPLES="${PROGRESS_EXAMPLES}" \
         -DPROGRESS_GRAPHLIB="${PROGRESS_GRAPHLIB}" \
-        -DBLAS_VENDOR="${BLAS_VENDOR}" \
         -DEXTRA_FCFLAGS="${EXTRA_FCFLAGS}" \
         -DEXTRA_LINK_FLAGS="${EXTRA_LINK_FLAGS}" \
         -DCMAKE_VERBOSE_MAKEFILE=${VERBOSE_MAKEFILE} \

--- a/example_build.sh
+++ b/example_build.sh
@@ -15,7 +15,6 @@ MY_PATH=`pwd`
 export CC=${CC:=gcc}
 export FC=${FC:=gfortran}
 export CXX=${CXX:=g++}
-export BLAS_VENDOR=${BLAS_VENDOR:=MKL}
 export PROGRESS_OPENMP=${PROGRESS_OPENMP:=yes}
 export INSTALL_DIR=${INSTALL_DIR:="${MY_PATH}/install"}
 export PROGRESS_GRAPHLIB=${PROGRESS_GRAPHLIB:=no}


### PR DESCRIPTION
We don't use BLAS directly in qmd-progress so we might as well remove this variable from the CMakeLists.txt file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/qmd-progress/124)
<!-- Reviewable:end -->
