### PR TITLE
Update prg_pulaycomponent_mod.F90

### DIFF
--- a/src/prg_pulaycomponent_mod.F90
+++ b/src/prg_pulaycomponent_mod.F90
@@ -41,7 +41,7 @@ contains
     real(dp), intent(in) :: threshold
     character(20), intent(in) :: bml_type
 
-    if(verbose.eq.1) write(*,*)"In prg_PulayComponent0 ..."
+    if(verbose.eq.2) write(*,*)"In prg_PulayComponent0 ..."
 
     nOrb = bml_get_N(rho_bml)
 
@@ -94,7 +94,7 @@ contains
     real(dp), intent(in) :: threshold
     character(20), intent(in) :: bml_type
 
-    if(verbose.eq.1) write(*,*)"In prg_PulayComponentT ..."
+    if(verbose.eq.2) write(*,*)"In prg_PulayComponentT ..."
 
     nOrb = bml_get_N(rho_bml)
 


### PR DESCRIPTION
LATTE is printing too much information from the mixer method when progress is enabled. Thus, I modified that to get cleaner output files. I hope this is not critical here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/qmd-progress/130)
<!-- Reviewable:end -->
