### PR TITLE
Fix logic around `EXTRA_FCFLAGS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,25 +46,25 @@ set(Intel_Fortran_FLAGS_RELEASE -O2 -g -assume realloc_lhs -qopt-report=5)
 
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none")
 option(DONT_TOUCH_MY_FLAGS "Don't touch compiler flags" OFF)
+if(NOT DONT_TOUCH_MY_FLAGS)
+  if(DEFINED EXTRA_FCFLAGS)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${EXTRA_FCFLAGS}")
+  endif()
+endif()
+message(STATUS "Setting Fortran compiler flags to ${CMAKE_Fortran_FLAGS}")
+
 if(CMAKE_BUILD_TYPE AND NOT DONT_TOUCH_MY_FLAGS)
   string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE)
   if(BUILD_TYPE STREQUAL "DEBUG" OR BUILD_TYPE STREQUAL "RELEASE")
-    if(CMAKE_Fortran_FLAGS STREQUAL "")
-      if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU"
-          OR CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-        set(CMAKE_Fortran_FLAGS_${BUILD_TYPE}
-          ${${CMAKE_Fortran_COMPILER_ID}_Fortran_FLAGS_${BUILD_TYPE}})
-        string(REPLACE ";" " "
-          CMAKE_Fortran_FLAGS_${BUILD_TYPE}
-          "${CMAKE_Fortran_FLAGS_${BUILD_TYPE}}")
-	if(DEFINED EXTRA_FCFLAGS)
-          set(CMAKE_Fortran_FLAGS_${BUILD_TYPE} "${CMAKE_Fortran_FLAGS_${BUILD_TYPE}} ${EXTRA_FCFLAGS}")
-	endif()
-        message(STATUS "Setting Fortran compiler flags to "
-          "${CMAKE_Fortran_FLAGS_${BUILD_TYPE}}")
-      else()
-        message(STATUS "Unknown Fortran compiler ${CMAKE_Fortran_COMPILER_ID}")
-      endif()
+    if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU"
+        OR CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+      set(CMAKE_Fortran_FLAGS_${BUILD_TYPE}
+        ${${CMAKE_Fortran_COMPILER_ID}_Fortran_FLAGS_${BUILD_TYPE}})
+      string(REPLACE ";" " "
+        CMAKE_Fortran_FLAGS_${BUILD_TYPE}
+        "${CMAKE_Fortran_FLAGS_${BUILD_TYPE}}")
+    else()
+      message(STATUS "Unknown Fortran compiler ${CMAKE_Fortran_COMPILER_ID}")
     endif()
   endif()
 endif()

--- a/build.sh
+++ b/build.sh
@@ -50,16 +50,16 @@ EOF
 set_defaults() {
     : ${CMAKE_BUILD_TYPE:=Release}
     : ${CMAKE_PREFIX_PATH:=""}
-    : "${CC:=gcc}"
-    : "${CXX:=g++}"
-    : "${FC:=gfortran}"
+    : ${CC:=gcc}
+    : ${CXX:=g++}
+    : ${FC:=gfortran}
     : ${BML_OPENMP:=yes}
     : ${PROGRESS_OPENMP:=yes}
     : ${PROGRESS_MPI:=no}
     : ${PROGRESS_TESTING:=no}
     : ${PROGRESS_EXAMPLES:=no}
     : ${PROGRESS_GRAPHLIB:=no}
-    : "${EXTRA_FCFLAGS:=}"
+    : ${EXTRA_FCFLAGS:=}
     : ${EXTRA_LINK_FLAGS:=""}
     : ${SANITY_CHECK:=no}
 }


### PR DESCRIPTION
The extra flags should be added regardless of the current value of the
compiler flags.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/qmd-progress/186)
<!-- Reviewable:end -->
