### PR TITLE
Store separate artifacts for jobs by name

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -87,6 +87,6 @@ jobs:
       - name: Archive example output
         uses: actions/upload-artifact@v2
         with:
-          name: example output
+          name: example output ${{ matrix.JOBNAME }}
           path: |
             examples/gpmdcov/out


### PR DESCRIPTION
This change will store the output of the gpmdcov job for comparisons
and debugging.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/qmd-progress/189)
<!-- Reviewable:end -->
