### PR TITLE
Add `repository_dispatch` event

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches:
       - master
+  repository_dispatch:
+    types:
+      - bml_update
   schedule:
     # Weekly on Sundays:
     - cron: '00 04 * * 0'


### PR DESCRIPTION
When the `bml` [1] is updated we would like to test this repository
with the most recent `bml` library code. This change adds the
`repository_dispatch` event to the workflow triggers.

This change is requires a change in the `bml` also which will be
submitted in a separate pull request.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/qmd-progress/199)
<!-- Reviewable:end -->
