### PR TITLE
Move tests to scripts

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,15 +22,6 @@ on:
 
 env:
   TEST_SETTINGS:
-  CC: gcc-10
-  FC: gfortran-10
-  CXX: g++-10
-  CMAKE_BUILD_TYPE: Debug
-  PKG_CONFIG_PATH: ~/bml/install/lib/pkgconfig:~/bml/install/lib64/pkgconfig
-  PROGRESS_EXAMPLES: yes
-  PROGRESS_OPENMP: yes
-  PROGRESS_TESTING: yes
-  VERBOSE_MAKEFILE: yes
 
 jobs:
   lint:
@@ -65,21 +56,10 @@ jobs:
       - run: ./scripts/prepare-container.sh
       - name: Install bml master
         env:
-          CC: ${{ matrix.CC || env.CC }}
-          FC: ${{ matrix.FC || env.FC }}
-          CXX: ${{ matrix.CXX || env.CXX }}
-          CMAKE_BUILD_TYPE: ${{ matrix.CMAKE_BUILD_TYPE || env.CMAKE_BUILD_TYPE }}
           TEST_SETTINGS: ${{ matrix.TEST_SETTINGS || env.TEST_SETTINGS }}
         run: ./scripts/install-bml.sh
       - name: Build and test library
         env:
-          CC: ${{ matrix.CC || env.CC }}
-          FC: ${{ matrix.FC || env.FC }}
-          CXX: ${{ matrix.CXX || env.CXX }}
-          PROGRESS_GRAPHLIB: ${{ matrix.PROGRESS_GRAPHLIB || env.PROGRESS_GRAPHLIB }}
-          OMP_NUM_THREADS: ${{ matrix.OMP_NUM_THREADS || env.OMP_NUM_THREADS }}
-          CMAKE_BUILD_TYPE: ${{ matrix.CMAKE_BUILD_TYPE || env.CMAKE_BUILD_TYPE }}
-          COMMAND: ${{ matrix.COMMAND || env.COMMAND }}
           TEST_SETTINGS: ${{ matrix.TEST_SETTINGS || env.TEST_SETTINGS }}
         run: |
           [[ -f ${TEST_SETTINGS} ]] && source ${TEST_SETTINGS}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -54,9 +54,7 @@ jobs:
           - JOBNAME: with graphlib, debug
             TEST_SETTINGS: ./scripts/ci-with-graphlib-debug.sh
           - JOBNAME: without graphlib, debug
-            PROGRESS_GRAPHLIB: yes
-            OMP_NUM_THREADS: 4
-            COMMAND: testing
+            TEST_SETTINGS: ./scripts/ci-without-graphlib-debug.sh
           - JOBNAME: graphlib, release
             PROGRESS_GRAPHLIB: no
             OMP_NUM_THREADS: 4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -55,11 +55,8 @@ jobs:
             TEST_SETTINGS: ./scripts/ci-with-graphlib-debug.sh
           - JOBNAME: without graphlib, debug
             TEST_SETTINGS: ./scripts/ci-without-graphlib-debug.sh
-          - JOBNAME: graphlib, release
-            PROGRESS_GRAPHLIB: no
-            OMP_NUM_THREADS: 4
-            CMAKE_BUILD_TYPE: Release
-            COMMAND: testing
+          - JOBNAME: with graphlib, release
+            TEST_SETTINGS: ./scripts/ci-with-graphlib-release.sh
           - JOBNAME: without graphlib, release
             PROGRESS_GRAPHLIB: yes
             OMP_NUM_THREADS: 4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -58,10 +58,7 @@ jobs:
           - JOBNAME: with graphlib, release
             TEST_SETTINGS: ./scripts/ci-with-graphlib-release.sh
           - JOBNAME: without graphlib, release
-            PROGRESS_GRAPHLIB: yes
-            OMP_NUM_THREADS: 4
-            CMAKE_BUILD_TYPE: Release
-            COMMAND: testing
+            TEST_SETTINGS: ./scripts/ci-without-graphlib-release.sh
     steps:
       - name: Check out sources
         uses: actions/checkout@v1

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -21,6 +21,7 @@ on:
   workflow_dispatch:
 
 env:
+  TEST_SETTINGS:
   CC: gcc-10
   FC: gfortran-10
   CXX: g++-10
@@ -50,10 +51,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - JOBNAME: graphlib, debug
-            PROGRESS_GRAPHLIB: no
-            OMP_NUM_THREADS: 4
-            COMMAND: testing
+          - JOBNAME: with graphlib, debug
+            TEST_SETTINGS: ./scripts/ci-with-graphlib-debug.sh
           - JOBNAME: without graphlib, debug
             PROGRESS_GRAPHLIB: yes
             OMP_NUM_THREADS: 4
@@ -78,6 +77,7 @@ jobs:
           FC: ${{ matrix.FC || env.FC }}
           CXX: ${{ matrix.CXX || env.CXX }}
           CMAKE_BUILD_TYPE: ${{ matrix.CMAKE_BUILD_TYPE || env.CMAKE_BUILD_TYPE }}
+          TEST_SETTINGS: ${{ matrix.TEST_SETTINGS || env.TEST_SETTINGS }}
         run: ./scripts/install-bml.sh
       - name: Build and test library
         env:
@@ -88,7 +88,10 @@ jobs:
           OMP_NUM_THREADS: ${{ matrix.OMP_NUM_THREADS || env.OMP_NUM_THREADS }}
           CMAKE_BUILD_TYPE: ${{ matrix.CMAKE_BUILD_TYPE || env.CMAKE_BUILD_TYPE }}
           COMMAND: ${{ matrix.COMMAND || env.COMMAND }}
-        run: ./build.sh ${COMMAND}
+          TEST_SETTINGS: ${{ matrix.TEST_SETTINGS || env.TEST_SETTINGS }}
+        run: |
+          [[ -f ${TEST_SETTINGS} ]] && source ${TEST_SETTINGS}
+          ./build.sh ${COMMAND}
       - name: Run gpmd example
         run: |
           pushd examples/gpmd

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Inside the container:
 
     $ ./build.sh compile
 
+Alternatively, you can run one of the CI tests by executing e.g.
+
+    $ ./scripts/ci-with-graphlib-debug.sh
+
 # Build and Install Instructions
 
 ## How to build

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,10 @@ Inside the container:
 
     $ ./build.sh compile
 
+Alternatively, you can run one of the CI tests by executing e.g.
+
+    $ ./scripts/ci-with-graphlib-debug.sh
+
 # Build and Install Instructions
 
 ## How to build

--- a/scripts/ci-defaults.sh
+++ b/scripts/ci-defaults.sh
@@ -1,0 +1,9 @@
+export CC=gcc-10
+export FC=gfortran-10
+export CXX=g++-10
+export CMAKE_BUILD_TYPE=Debug
+export PKG_CONFIG_PATH=~/bml/install/lib/pkgconfig:~/bml/install/lib64/pkgconfig
+export PROGRESS_EXAMPLES=yes
+export PROGRESS_OPENMP=yes
+export PROGRESS_TESTING=yes
+export VERBOSE_MAKEFILE=yes

--- a/scripts/ci-with-graphlib-debug.sh
+++ b/scripts/ci-with-graphlib-debug.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e -u -x
+
+basedir=$(readlink --canonicalize $(dirname ${BASH_SOURCE[0]})/..)
+
+[[ -f ${basedir}/scripts/ci-defaults.sh ]] && . ${basedir}/scripts/ci-defaults.sh
+
+export PROGRESS_GRAPHLIB=yes
+export OMP_NUM_THREADS=4
+export COMMAND=testing

--- a/scripts/ci-with-graphlib-release.sh
+++ b/scripts/ci-with-graphlib-release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e -u -x
+
+basedir=$(readlink --canonicalize $(dirname ${BASH_SOURCE[0]})/..)
+
+[[ -f ${basedir}/scripts/ci-defaults.sh ]] && . ${basedir}/scripts/ci-defaults.sh
+
+export PROGRESS_GRAPHLIB=yes
+export OMP_NUM_THREADS=4
+export COMMAND=testing
+export CMAKE_BUILD_TYPE=Release

--- a/scripts/ci-without-graphlib-debug.sh
+++ b/scripts/ci-without-graphlib-debug.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e -u -x
+
+basedir=$(readlink --canonicalize $(dirname ${BASH_SOURCE[0]})/..)
+
+[[ -f ${basedir}/scripts/ci-defaults.sh ]] && . ${basedir}/scripts/ci-defaults.sh
+
+export PROGRESS_GRAPHLIB=no
+export OMP_NUM_THREADS=4
+export COMMAND=testing

--- a/scripts/ci-without-graphlib-release.sh
+++ b/scripts/ci-without-graphlib-release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e -u -x
+
+basedir=$(readlink --canonicalize $(dirname ${BASH_SOURCE[0]})/..)
+
+[[ -f ${basedir}/scripts/ci-defaults.sh ]] && . ${basedir}/scripts/ci-defaults.sh
+
+export PROGRESS_GRAPHLIB=no
+export OMP_NUM_THREADS=4
+export COMMAND=testing
+export CMAKE_BUILD_TYPE=Release

--- a/scripts/install-bml.sh
+++ b/scripts/install-bml.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-set -e -x
+set -e -u -x
+
+if [[ -v TEST_SETTINGS ]]; then
+  [[ -f ${TEST_SETTINGS} ]] && source ${TEST_SETTINGS}
+fi
 
 cd ~
 git clone https://github.com/lanl/bml.git


### PR DESCRIPTION
By moving the tests into separate scripts it will be easier to run
specific tests outside CI for debugging.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/qmd-progress/201)
<!-- Reviewable:end -->
