### PR TITLE
Do not fail fast in CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -48,6 +48,7 @@ jobs:
     name: Build and test (${{ matrix.JOBNAME }})
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - JOBNAME: graphlib, debug


### PR DESCRIPTION
By allowing all jobs to finish before failing the CI tests we will get
a more complete picture of the state of a pull request. This should
help in preparing a better pull request.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/qmd-progress/202)
<!-- Reviewable:end -->
