### PR TITLE
Fix bug in fermi function: Floating-point exception in debug mode

### DIFF
--- a/src/prg_densitymatrix_mod.F90
+++ b/src/prg_densitymatrix_mod.F90
@@ -628,8 +628,12 @@ contains
 
     real(dp), intent(in) :: e, ef, kbt
 
-    fermi = 1.0_dp/(1.0_dp+exp((e-ef)/(kbt)))
-
+    if ((e-ef)/kbt > 100.0_dp) then
+      fermi = 0.0_dp
+    else
+      fermi = 1.0_dp/(1.0_dp+exp((e-ef)/(kbt)))
+    endif
+   
   end function fermi
 
 end module prg_densitymatrix_mod


### PR DESCRIPTION
A small fix to the floating point exception in debug mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/qmd-progress/221)
<!-- Reviewable:end -->
