### PR TITLE
Vectorize H and dH methods

### DIFF
--- a/src/latte_mods/ham_latte_mod.F90
+++ b/src/latte_mods/ham_latte_mod.F90
@@ -14,7 +14,7 @@ module ham_latte_mod
 
   integer, parameter :: dp = kind(1.0d0)
 
-  public :: get_hindex, get_hindex_coreHalo, get_hsmat, get_SKBlock
+  public :: get_hindex, get_hindex_coreHalo, get_hsmat, get_hsmat_vect, get_SKBlock, get_SKBlock_vect
 
 contains
 
@@ -244,6 +244,190 @@ contains
 
   end subroutine get_hsmat
 
+    !> Constructs Hamiltonian and Overlap Matrix
+  !! \brief Construction of the Hamiltonian and Overlap matrix.
+  !! \param ham_bml Hamiltonian in bml format.
+  !! \param over_bml Overlap in bml format.
+  !! \param coordinate Coordinates of the system. This can be getter from the system type:
+  !! \verbatim system%coordinate \endverbatim
+  !! \param lattice_vector Lattice vectors for the system.
+  !! \param spindex Species indices (see system_type).
+  !! \param norbi Number of orbital for every species.
+  !! \param hindex Contains the Hamiltonian indices for every atom (see get_hindex)
+  !! \param onsitesH Onsites energies for every pair of equal type. Allocation:
+  !! \verbatim onsitesH(maxints,nsp) \endverbatim
+  !! \param onsitesS Same as the Hamiltonian but for the overlap matrix.
+  !! In this case the "onsite" elements are equal to 1.0. This was done to maintain
+  !! a consistency and have the possibility of generalize the SK block construction.
+  !! elements are or the same type.
+  !! \param intPairsH,intPairsS See in intPairs_type
+  !! \param threshold Threshold value for matrix elements.
+  subroutine get_hsmat_vect(ham_bml,over_bml,coordinate,lattice_vector,spindex,&
+       norbi,hindex,onsitesH,onsitesS,intPairsH,intPairsS,threshold)
+    implicit none
+    character(20)                       ::  bml_type, bml_dmode
+    integer                             ::  dimi, dimj, i, ii
+    integer                             ::  j, jj, nats, norb, mdim
+    integer, intent(in)                 ::  hindex(:,:), norbi(:), spindex(:)
+    integer                             ::  maxnorbi
+    real(dp)                            ::  ra(3), rb(3)
+    real(dp), allocatable               ::  block(:,:,:), ham(:,:), over(:,:), ham_vect(:,:), over_vect(:,:)
+    real(dp), intent(in)                ::  coordinate(:,:), lattice_vector(:,:), onsitesH(:,:), onsitesS(:,:)
+    real(dp), intent(in)                ::  threshold
+    type(bml_matrix_t), intent(inout)   ::  ham_bml, over_bml
+    type(intpairs_type), intent(in)     ::  intPairsH(:,:), intPairsS(:,:)
+    real(dp), allocatable               ::  intParams1(:,:,:), intParams2(:,:,:)
+    integer, allocatable                ::  norbs_atidx(:)
+
+    nats = size(spindex,dim=1)
+    norb = bml_get_N(ham_bml)
+    mdim = bml_get_M(ham_bml)
+    bml_type = bml_get_type(ham_bml)
+    bml_dmode = bml_get_distribution_mode(ham_bml)
+
+    !     if(bml_get_N(ham_bml).LE.0) then  !Carefull we need to clean S and H before rebuilding them!!!
+    call bml_deallocate(ham_bml)
+    call bml_deallocate(over_bml)
+    call bml_zero_matrix(bml_type,bml_element_real,dp,norb,mdim,ham_bml, &
+         bml_dmode)
+    call bml_zero_matrix(bml_type,bml_element_real,dp,norb,mdim,over_bml, &
+         bml_dmode)
+    !     endif
+
+    maxnorbi = maxval(norbi)
+
+    if(.not.allocated(ham)) then
+      allocate(ham(norb,norb))
+      allocate(ham_vect(norb,norb))
+    endif
+    if(.not.allocated(over)) then
+      allocate(over(norb,norb))
+      allocate(over_vect(norb,norb))
+    endif
+
+    if (.not.allocated(block)) then
+      allocate(block(maxnorbi,maxnorbi,nats))
+    endif
+
+    if (.not.allocated(norbs_atidx)) then
+       allocate(norbs_atidx(nats))
+    endif
+    do i=1,nats
+       norbs_atidx(i) = norbi(spindex(i))
+    enddo
+    ! !$omp parallel do default(none) &
+    ! !$omp private(ra,rb,dimi,dimj,ii,jj,j) &
+    ! !$omp shared(nats,coordinate,hindex,spindex, intPairsS,intPairsH,threshold,lattice_vector,norbi,onsitesH,onsitesS,ham_bml,over_bml) &
+    ! !$omp shared(block,ham,over)
+    ! do i = 1, nats
+    !   ra(:) = coordinate(:,i)
+    !   dimi = hindex(2,i)-hindex(1,i)+1
+    !   do j = 1, nats
+    !     rb(:) = coordinate(:,j)
+    !     dimj = hindex(2,j)-hindex(1,j)+1
+    !     !Hamiltonian block for a-b atom pair
+    !     call get_SKBlock(spindex(i),spindex(j),coordinate(:,i),&
+    !          coordinate(:,j),lattice_vector,norbi,&
+    !          onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,block,i)
+
+    !     do jj=1,dimj
+    !       do ii=1,dimi
+    !         ham(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = block(ii,jj,i)
+    !       enddo
+    !     enddo
+
+    !     call get_SKBlock(spindex(i),spindex(j),coordinate(:,i),&
+    !          coordinate(:,j),lattice_vector,norbi,&
+    !          onsitesS,intPairsS(spindex(i),spindex(j))%intParams,intPairsS(spindex(j),spindex(i))%intParams,block,i)
+
+    !     do jj=1,dimj
+    !       do ii=1,dimi
+    !         over(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = block(ii,jj,i)
+    !       enddo
+    !     enddo
+
+    !     !  write(*,*)spindex(i),spindex(j)
+    !     !  write(*,'(100F10.5)')intPairsS(spindex(i),spindex(j))%intParams
+    !     ! call prg_print_matrix("block",block(:,:,i),1,4,1,4)
+
+    !   enddo
+    ! enddo
+
+    !!$omp end parallel do
+
+    allocate(intParams1(nats,16,4))
+    allocate(intParams2(nats,16,4))
+
+    !$omp parallel do default(none) &
+    !$omp private(ra,rb,dimi,dimj,ii,jj,j,intParams1,intParams2) &
+    !$omp shared(nats,coordinate,hindex,spindex, intPairsS,intPairsH,threshold,lattice_vector,norbs_atidx,onsitesH,onsitesS,ham_bml,over_bml) &
+    !$omp shared(ham_vect,over_vect)
+    do i = 1, nats
+       do j = 1,nats
+          intParams1(j,:,:) = intPairsH(spindex(i),spindex(j))%intParams(:,1:4)
+          intParams2(j,:,:) = intPairsH(spindex(j),spindex(i))%intParams(:,1:4)
+       enddo
+          
+        call get_SKBlock_vect(spindex,coordinate(:,:),lattice_vector,norbs_atidx,&
+             onsitesH,intParams1(:,:,:),intParams2(:,:,:),ham_vect(hindex(1,i):hindex(2,i),:),i)
+
+       do j = 1,nats
+          intParams1(j,:,:) = intPairsS(spindex(i),spindex(j))%intParams(:,1:4)
+          intParams2(j,:,:) = intPairsS(spindex(j),spindex(i))%intParams(:,1:4)
+       enddo
+
+       call get_SKBlock_vect(spindex,coordinate(:,:),lattice_vector,norbs_atidx,&
+            onsitesS,intParams1(:,:,:),intParams2(:,:,:),over_vect(hindex(1,i):hindex(2,i),:),i)
+        
+        !  write(*,*)spindex(i),spindex(j)
+        !  write(*,'(100F10.5)')intPairsS(spindex(i),spindex(j))%intParams
+        ! call prg_print_matrix("block",block(:,:,i),1,4,1,4)
+
+    enddo
+
+    !$omp end parallel do
+
+    ! if(.not.all(abs(ham-ham_vect).lt.1.D-12))then
+    !    do i = 1,norb
+    !       do j = 1,norb
+    !          if(abs(ham(i,j)-ham_vect(i,j)).ge.1.D-12)then
+    !             write(*,*)"GET_SKBLOCK_VECT: Vectorized ham differs at i,j = ",i,j,"with difference ",ham(i,j)-ham_vect(i,j)
+    !          endif
+    !       enddo
+    !    enddo
+    ! endif
+    ! if(.not.all(abs(over-over_vect).lt.1.D-12))then
+    !    do i = 1,norb
+    !       do j = 1,norb
+    !          if(abs(over(i,j)-over_vect(i,j)).ge.1.D-12)then
+    !             write(*,*)"GET_SKBLOCK_VECT: Vectorized over differs at i,j = ",i,j,"with difference ",over(i,j)-over_vect(i,j)
+    !          endif
+    !       enddo
+    !    enddo
+    ! endif
+    ! write(*,*)"ham(1,:) = ",ham(1,:)
+    ! write(*,*)"ham_vect(1,:) = ",ham_vect(1,:)
+    ! write(*,*)"ham(2,:) = ",ham(2,:)
+    ! write(*,*)"ham_vect(2,:) = ",ham_vect(2,:)
+    bml_type=bml_get_type(ham_bml) !Get the bml type
+    call bml_import_from_dense(bml_type,over_vect,over_bml,threshold,norb) !Dense to dense_bml
+    call bml_import_from_dense(bml_type,ham_vect,ham_bml,threshold,norb) !Dense to dense_bml
+
+    if(allocated(ham)) then
+       deallocate(ham)
+       deallocate(ham_vect)
+    endif
+    if(allocated(over)) then
+      deallocate(over)
+      deallocate(over_vect)
+    endif
+    deallocate(intParams1)
+    deallocate(intParams2)
+
+    !     call bml_print_matrix("ham_bml",ham_bml,0,6,0,6)
+    !     call bml_print_matrix("over_bml",over_bml,0,6,0,6)
+
+  end subroutine get_hsmat_vect
   !> Function to calculate the bond integral for a given distance
   !! and coefficients set.
   !! \param dr distance between atoms.
@@ -270,6 +454,70 @@ contains
     bondintegral = f(1)*x
 
   end function bondintegral
+
+  !> Function to calculate the bond integral for a given distance
+  !! and coefficients set.
+  !! \param dr distance between atoms.
+  !! \param f parameters (coefficients) for the bond integral.
+  function bondIntegral_vect(dr,f) result(x)
+    implicit none
+    real(dp), allocatable :: dr_m(:), f_m(:,:)
+    real(dp), allocatable :: rmod(:)
+    real(dp), allocatable :: polynom(:)
+    real(dp), allocatable :: rminusr1(:)
+    real(dp), allocatable :: low_x(:), mid_x(:)
+    real(dp), intent(in) :: dr(:)
+    real(dp), intent(in) :: f(:,:)
+    real(dp)             :: x(size(dr))
+    logical, allocatable :: low_mask(:),mid_mask(:)
+    integer              :: vect_size, mask_size
+    
+    vect_size = size(dr)
+    
+    allocate(low_mask(vect_size))
+
+    low_mask = dr.le.f(:,7)
+
+    dr_m = pack(dr,low_mask)
+    mask_size = size(dr_m)
+    allocate(f_m(mask_size,16))
+    f_m = reshape(pack(f,spread(low_mask,dim=2,ncopies=16)),(/mask_size,16/))
+    
+    allocate(rmod(mask_size))    
+    rmod = dr_m - f_m(:,6)
+    allocate(polynom(mask_size))
+    polynom = rmod*(f_m(:,2) + rmod*(f_m(:,3) + rmod*(f_m(:,4) + f_m(:,5)*rmod)));
+    allocate(low_x(mask_size))
+    low_x = exp(polynom(:))
+
+    mid_mask = dr.gt.f(:,7).and.dr.lt.f(:,8)
+    dr_m = pack(dr,mid_mask)
+    mask_size = size(dr_m)
+    deallocate(f_m)
+    allocate(f_m(mask_size,16))
+    f_m = reshape(pack(f,spread(mid_mask,dim=2,ncopies=16)),(/mask_size,16/))
+    allocate(rminusr1(mask_size))
+    rminusr1 = dr_m(:) - f_m(:,7)
+    allocate(mid_x(mask_size))
+    mid_x = f_m(:,9) + rminusr1*(f_m(:,10) + rminusr1*(f_m(:,11) + rminusr1*(f_m(:,12) + rminusr1*(f_m(:,13) + rminusr1*f_m(:,14)))))
+
+    x = 0.0_dp
+
+    x = unpack(low_x,low_mask,x)
+    x = unpack(mid_x,mid_mask,x)
+
+    x = f(:,1)*x
+    deallocate(low_mask)
+    deallocate(mid_mask)
+    deallocate(mid_x)
+    deallocate(low_x)
+    deallocate(rminusr1)
+    deallocate(f_m)
+    deallocate(dr_m)
+    deallocate(polynom)
+    deallocate(rmod)
+    
+  end function bondintegral_vect
 
   !> Standard Slater-Koster sp-parameterization for an atomic block between a pair of atoms
   !! \param sp1 Species index for atom 1. This can be obtained from the
@@ -423,5 +671,271 @@ contains
    !            write(*,*)"block",dr,block
    !            stop
  end subroutine get_SKBlock
+
+  !> Standard Slater-Koster sp-parameterization for an atomic block between a pair of atoms
+  !! \param sp1 Species index for atom 1. This can be obtained from the
+  !! system type as following:
+  !! \verbatim sp1 = system%spindex(atom1) \endverbatim
+  !! \param sp2 Species index for atom 2.
+  !! \param coorda Coordinates for atom 1.
+  !! \param coordb Coordinates for atom 2.
+  !! \param lattice_vectors Lattice vectors for the system. This can be obtained from
+  !! the system type as following:
+  !! \verbatim lattice_vectors = system%lattice_vectors \endverbatim
+  !! \param norbi Number of orbitals for every species in the system. This can be obtained from
+  !! the tbparams type as following:
+  !! \verbatim norbi = tbparams%norbi \endverbatim
+  !! \param onsites Onsites energies for every pair of equal type. Two different variants
+  !! onsitesH and onsitesS will be used as inputs (see get_hsmat routine) Allocation:
+  !! \verbatim onsites(maxints,nsp) \endverbatim
+  !! \param intParams See intpairs_type.
+  !! \param block Output parameter SK block.
+  !! \param atnum Input atom number
+  subroutine get_SKBlock_vect(sp,coord,lattice_vectors&
+       ,norbs,onsites,intParams1,intParams2,blk,atnum)
+    implicit none
+    integer                              ::  dimi, dimj, i, nr_shift_X
+    integer                              ::  nr_shift_Y, nr_shift_Z, nats, norbsall, mask_size, iorb
+    integer, intent(in)                  ::  norbs(:), sp(:), atnum
+    real(dp), allocatable                ::  HPPP(:), HPPS(:), HSPS(:), HSSS(:), PPSMPP(:)
+    real(dp), allocatable                ::  L(:), M(:), N(:)
+    real(dp), allocatable                ::  dr(:), dr_m(:), rab(:,:)
+    real(dp), allocatable                ::  dx_m(:), dy_m(:), dz_m(:), blk_m(:,:,:), onsites_m(:)
+    real(dp), intent(inout) ::  blk(:,:)
+    real(dp), intent(in)                 ::  coord(:,:), lattice_vectors(:,:)
+    real(dp), intent(in)                 ::  onsites(:,:)
+    real(dp), intent(in)                 ::  intParams1(:,:,:),intParams2(:,:,:)
+    logical, allocatable                 ::  dist_mask(:), onsite_mask(:), calc_mask(:), calcs_mask(:), calcsp_mask(:), param_mask(:,:), calc_mask_for_porbs(:)
+    logical, allocatable                 ::  sorb_mask(:), pxorb_mask(:), pyorb_mask(:), pzorb_mask(:)
+    logical, allocatable                 ::  sorb_at_mask(:), sporb_at_mask(:)
+    integer, allocatable                 ::  atomidx(:), atomidx_m(:), orbidx(:), orbidx_m(:), orbidx_sel(:)
+    real(dp), allocatable                ::  intParams(:,:)
+
+    nats = size(coord,dim=2)
+    write(*,*)"GET_SKBLOCK_VECT: nats = ",nats,"when atnum = ",atnum
+    norbsall = sum(norbs)
+    
+    blk(:,:)=0.0_dp
+
+    if(allocated(dr))then
+       if(nats.ne.size(dr,dim=1))then
+          deallocate(dr)
+          deallocate(atomidx)
+          deallocate(orbidx)
+          deallocate(rab)
+          deallocate(dist_mask)
+          deallocate(onsite_mask)
+          deallocate(calc_mask)
+          deallocate(calcs_mask)
+          deallocate(calcsp_mask)
+          deallocate(param_mask)
+          deallocate(sorb_mask)
+          deallocate(pxorb_mask)
+          deallocate(pyorb_mask)
+          deallocate(pzorb_mask)
+          deallocate(sorb_at_mask)
+          deallocate(sporb_at_mask)
+       endif
+    endif
+    if(.not.allocated(dr))then
+       allocate(dr(nats))
+       allocate(atomidx(nats))
+       atomidx = (/(i,i=1,nats)/)
+       allocate(orbidx(norbsall))
+       orbidx = (/(i,i=1,norbsall)/)
+       allocate(rab(nats,3))
+       allocate(dist_mask(nats))
+       allocate(onsite_mask(nats))
+       allocate(calc_mask(nats))
+       allocate(calcs_mask(nats))
+       allocate(calcsp_mask(nats))
+       allocate(param_mask(nats,16))
+       allocate(sorb_at_mask(nats))
+       allocate(sporb_at_mask(nats))
+       allocate(sorb_mask(norbsall))
+       allocate(pxorb_mask(norbsall))
+       allocate(pyorb_mask(norbsall))
+       allocate(pzorb_mask(norbsall))
+       sorb_at_mask = .false.
+       sporb_at_mask = .false.
+       onsite_mask = .false.
+       sorb_mask = .false.
+       pxorb_mask = .false.
+       pyorb_mask = .false.
+       pzorb_mask = .false.
+       iorb = 1
+       do i = 1,nats
+          if(i.eq.atnum)then
+             onsite_mask(i) = .true.
+             blk(1,iorb) = onsites(1,sp(atnum))
+             if(norbs(i).eq.4)then
+                blk(2,iorb+1) = onsites(2,sp(atnum))
+                blk(3,iorb+2) = onsites(3,sp(atnum))
+                blk(4,iorb+3) = onsites(4,sp(atnum))
+             endif
+          endif
+          sorb_mask(iorb) = .true.
+          iorb = iorb + 1
+          if(norbs(i).eq.1)then
+             sorb_at_mask(i) = .true.
+          elseif(norbs(i).eq.4)then
+             sporb_at_mask(i) = .true.
+             pxorb_mask(iorb) = .true.
+             pyorb_mask(iorb+1) = .true.
+             pzorb_mask(iorb+2) = .true.
+             iorb = iorb + 3
+          else
+             write(*,*)"GET_SKBLOCK_VECT: number of orbitals not 1 or 4 for atom ",i,": ABORT"
+             stop
+          endif
+       enddo
+    endif
+    
+    do i = 1,3
+       Rab(:,i) = coord(i,:)
+       Rab(:,i) = modulo((Rab(:,i) - coord(i,atnum) + 0.5_dp*lattice_vectors(i,i)),lattice_vectors(i,i)) - 0.5_dp * lattice_vectors(i,i)
+    enddo
+
+    dR(:) = norm2(Rab(:,:),dim=2)
+
+    dist_mask = dr.lt.6.5_dp
+    calc_mask = dist_mask.and..not.onsite_mask
+    calcsp_mask = calc_mask.and.sporb_at_mask
+    calcs_mask = calc_mask.and.sorb_at_mask
+    ! First mask using the s orbitals
+    ! The s-s term for all atoms is the same in this case
+    ! The sorb_mask has the same number of .true. elements as the calc_mask
+    orbidx_m = pack(orbidx,mask=sorb_mask)
+    orbidx_sel = pack(orbidx_m,mask=calc_mask)
+    atomidx_m = pack(atomidx,mask=calc_mask)
+    mask_size = size(atomidx_m)
+    dr_m = pack(dr,calc_mask)
+    dx_m = pack(rab(:,1),calc_mask)
+    dy_m = pack(rab(:,2),calc_mask)
+    dz_m = pack(rab(:,3),calc_mask)
+    allocate(intParams(mask_size,16))
+    intParams(:,:) = intParams1(atomidx_m(:),:,1)
+    blk(1,orbidx_sel) = BondIntegral_vect(dr_m,intParams)
+    deallocate(intParams)
+    deallocate(atomidx_m)
+    deallocate(orbidx_sel)
+    deallocate(dr_m)
+    deallocate(dx_m)
+    deallocate(dy_m)
+    deallocate(dz_m)
+    ! If the atnum atom is a sp atom, calculate the p*-s elements for
+    !   s orbital atoms and sp orbital atoms separately. Do the s orbital
+    !   atoms first here.
+    if(norbs(atnum).eq.4)then
+       ! First the s orbital atoms
+       atomidx_m = pack(atomidx,mask=calcs_mask)
+       mask_size = size(atomidx_m)
+       allocate(intParams(mask_size,16))
+       allocate(HSPS(mask_size))
+       intParams(:,:) = intParams1(atomidx_m(:),:,2)
+       dr_m = pack(dr,calcs_mask)
+       HSPS = BondIntegral_vect(dr_m,intParams)
+       dx_m = pack(rab(:,1),calcs_mask)
+       dy_m = pack(rab(:,2),calcs_mask)
+       dz_m = pack(rab(:,3),calcs_mask)
+       L = dx_m/dr_m
+       M = dy_m/dr_m
+       N = dz_m/dr_m
+       orbidx_sel = pack(orbidx_m,mask=calcs_mask) ! orbidx_m still is the s orbital mask
+       write(*,*)"GET_SKBLOCK_VECT: S atom S orbital calc mask for atom ",atnum,"= ",orbidx_sel
+       if(size(orbidx_sel).ne.size(atomidx_m))then
+          write(*,*)"GET_SKBLOCK_VECT: size mismatch of orbital and atom index arrays. Abort."
+          stop
+       endif
+       blk(2,orbidx_sel) = - L * HSPS
+       blk(3,orbidx_sel) = - M * HSPS
+       blk(4,orbidx_sel) = - N * HSPS
+       deallocate(intParams)
+       deallocate(HSPS)
+       deallocate(dr_m)
+       deallocate(dx_m)
+       deallocate(dy_m)
+       deallocate(dz_m)
+       deallocate(orbidx_sel)
+       deallocate(atomidx_m)
+    endif
+    ! Now work on the sp orbital atoms
+   ! First create some common masked arrays
+    atomidx_m = pack(atomidx,mask=calcsp_mask)
+    mask_size = size(atomidx_m)
+    dr_m = pack(dr,calcsp_mask)
+    dx_m = pack(rab(:,1),calcsp_mask)
+    dy_m = pack(rab(:,2),calcsp_mask)
+    dz_m = pack(rab(:,3),calcsp_mask)
+    L = dx_m/dr_m
+    M = dy_m/dr_m
+    N = dz_m/dr_m
+    ! Now work on the p*-s elements first, if relevant
+    allocate(intParams(mask_size,16))
+    allocate(HSPS(mask_size))
+    if(norbs(atnum).eq.4)then
+       intParams(:,:) = intParams2(atomidx_m(:),:,2)
+       HSPS = BondIntegral_vect(dr_m,intParams)
+       orbidx_sel = pack(orbidx_m,mask=calcsp_mask) ! orbidx_m still is the s orbital mask
+       if(size(orbidx_sel).ne.size(atomidx_m))then
+          write(*,*)"GET_SKBLOCK_VECT: size mismatch of orbital and sp atom index arrays. Abort."
+          stop
+       endif
+       blk(2,orbidx_sel) = - L * HSPS
+       blk(3,orbidx_sel) = - M * HSPS
+       blk(4,orbidx_sel) = - N * HSPS
+       deallocate(orbidx_sel)
+    endif
+    ! At this point all of the s orbital calculations are done. Move on to p orbitals.
+    calc_mask_for_porbs = pack(calc_mask,sporb_at_mask)
+    intParams(:,:) = intParams1(atomidx_m(:),:,2)
+    HSPS = BondIntegral_vect(dr_m,intParams)
+    if(norbs(atnum).eq.4)then ! Calculate extra params if the reference atom is sp type
+       allocate(HPPP(mask_size))
+       allocate(PPSMPP(mask_size))
+       intParams(:,:) = intParams1(atomidx_m(:),:,3)
+       PPSMPP = BondIntegral_vect(dr_m,intParams)
+       intParams(:,:) = intParams1(atomidx_m(:),:,4)
+       HPPP = BondIntegral_vect(dr_m,intParams)
+       PPSMPP = PPSMPP - HPPP
+    endif
+    deallocate(orbidx_m)
+    orbidx_m = pack(orbidx,mask=pxorb_mask) ! Select px orbitals
+    orbidx_sel = pack(orbidx_m,calc_mask_for_porbs)
+    blk(1,orbidx_sel) = + L(:) * HSPS(:)
+    if(norbs(atnum).eq.4)then
+       blk(2,orbidx_sel) = HPPP + L*L*PPSMPP
+       blk(3,orbidx_sel) = M*L*PPSMPP
+       blk(4,orbidx_sel) = N*L*PPSMPP
+    endif
+    deallocate(orbidx_m)
+    deallocate(orbidx_sel)
+    orbidx_m = pack(orbidx,mask=pyorb_mask) ! Select py orbitals
+    orbidx_sel = pack(orbidx_m,calc_mask_for_porbs)
+    blk(1,orbidx_sel) = + M(:) * HSPS(:)
+    if(norbs(atnum).eq.4)then
+       blk(2,orbidx_sel) = L*M*PPSMPP
+       blk(3,orbidx_sel) = HPPP + M*M*PPSMPP
+       blk(4,orbidx_sel) = N*M*PPSMPP
+    endif
+    deallocate(orbidx_m)
+    deallocatE(orbidx_sel)
+    orbidx_m = pack(orbidx,mask=pzorb_mask) ! Select pz orbitals
+    orbidx_sel = pack(orbidx_m,calc_mask_for_porbs)
+    blk(1,orbidx_sel) = + N(:) * HSPS(:)
+    if(norbs(atnum).eq.4)then
+       blk(2,orbidx_sel) = L*N*PPSMPP
+       blk(3,orbidx_sel) = M*N*PPSMPP
+       blk(4,orbidx_sel) = HPPP + N*N*PPSMPP
+       deallocate(HPPP)
+    endif
+    deallocate(orbidx_m)
+    deallocatE(orbidx_sel)
+    deallocate(calc_mask_for_porbs)
+    deallocate(HSPS)
+    deallocate(intParams)
+! if(.false.)then
+!  endif   
+ end subroutine get_SKBlock_vect
 
 end module ham_latte_mod

--- a/src/latte_mods/ham_latte_mod.F90
+++ b/src/latte_mods/ham_latte_mod.F90
@@ -884,25 +884,25 @@ contains
        blk(3,orbidx_sel) = M*L*PPSMPP
        blk(4,orbidx_sel) = N*L*PPSMPP
     endif
-    deallocate(orbidx_m)
-    deallocate(orbidx_sel)
-    orbidx_m = pack(orbidx,mask=pyorb_mask) ! Select py orbitals
-    orbidx_sel = pack(orbidx_m,calc_mask_for_porbs)
-    blk(1,orbidx_sel) = + M(:) * HSPS(:)
+    ! deallocate(orbidx_m)
+    ! deallocate(orbidx_sel)
+    ! orbidx_m = pack(orbidx,mask=pyorb_mask) ! Select py orbitals
+    ! orbidx_sel = pack(orbidx_m,calc_mask_for_porbs)
+    blk(1,orbidx_sel+1) = + M(:) * HSPS(:)
     if(norbs(atnum).eq.4)then
-       blk(2,orbidx_sel) = L*M*PPSMPP
-       blk(3,orbidx_sel) = HPPP + M*M*PPSMPP
-       blk(4,orbidx_sel) = N*M*PPSMPP
+       blk(2,orbidx_sel+1) = L*M*PPSMPP
+       blk(3,orbidx_sel+1) = HPPP + M*M*PPSMPP
+       blk(4,orbidx_sel+1) = N*M*PPSMPP
     endif
-    deallocate(orbidx_m)
-    deallocatE(orbidx_sel)
-    orbidx_m = pack(orbidx,mask=pzorb_mask) ! Select pz orbitals
-    orbidx_sel = pack(orbidx_m,calc_mask_for_porbs)
-    blk(1,orbidx_sel) = + N(:) * HSPS(:)
+    ! deallocate(orbidx_m)
+    ! deallocatE(orbidx_sel)
+    ! orbidx_m = pack(orbidx,mask=pzorb_mask) ! Select pz orbitals
+    ! orbidx_sel = pack(orbidx_m,calc_mask_for_porbs)
+    blk(1,orbidx_sel+2) = + N(:) * HSPS(:)
     if(norbs(atnum).eq.4)then
-       blk(2,orbidx_sel) = L*N*PPSMPP
-       blk(3,orbidx_sel) = M*N*PPSMPP
-       blk(4,orbidx_sel) = HPPP + N*N*PPSMPP
+       blk(2,orbidx_sel+2) = L*N*PPSMPP
+       blk(3,orbidx_sel+2) = M*N*PPSMPP
+       blk(4,orbidx_sel+2) = HPPP + N*N*PPSMPP
        deallocate(HPPP)
     endif
     deallocate(orbidx_m)

--- a/src/latte_mods/ham_latte_mod.F90
+++ b/src/latte_mods/ham_latte_mod.F90
@@ -368,7 +368,7 @@ contains
           intParams2(j,:,:) = intPairsH(spindex(j),spindex(i))%intParams(:,1:4)
        enddo
           
-        call get_SKBlock_vect(spindex,coordinate(:,:),lattice_vector,norbs_atidx,&
+        call get_SKBlock_vect(spindex,coordinate(:,i),coordinate(:,:),lattice_vector,norbs_atidx,&
              onsitesH,intParams1(:,:,:),intParams2(:,:,:),ham_vect(hindex(1,i):hindex(2,i),:),i)
 
        do j = 1,nats
@@ -376,7 +376,7 @@ contains
           intParams2(j,:,:) = intPairsS(spindex(j),spindex(i))%intParams(:,1:4)
        enddo
 
-       call get_SKBlock_vect(spindex,coordinate(:,:),lattice_vector,norbs_atidx,&
+       call get_SKBlock_vect(spindex,coordinate(:,i),coordinate(:,:),lattice_vector,norbs_atidx,&
             onsitesS,intParams1(:,:,:),intParams2(:,:,:),over_vect(hindex(1,i):hindex(2,i),:),i)
         
         !  write(*,*)spindex(i),spindex(j)
@@ -691,7 +691,7 @@ contains
   !! \param intParams See intpairs_type.
   !! \param block Output parameter SK block.
   !! \param atnum Input atom number
-  subroutine get_SKBlock_vect(sp,coord,lattice_vectors&
+  subroutine get_SKBlock_vect(sp,refcoord,coord,lattice_vectors&
        ,norbs,onsites,intParams1,intParams2,blk,atnum)
     implicit none
     integer                              ::  dimi, dimj, i, nr_shift_X
@@ -702,7 +702,7 @@ contains
     real(dp), allocatable                ::  dr(:), dr_m(:), rab(:,:)
     real(dp), allocatable                ::  dx_m(:), dy_m(:), dz_m(:), blk_m(:,:,:), onsites_m(:)
     real(dp), intent(inout) ::  blk(:,:)
-    real(dp), intent(in)                 ::  coord(:,:), lattice_vectors(:,:)
+    real(dp), intent(in)                 ::  refcoord(:),coord(:,:), lattice_vectors(:,:)
     real(dp), intent(in)                 ::  onsites(:,:)
     real(dp), intent(in)                 ::  intParams1(:,:,:),intParams2(:,:,:)
     logical, allocatable                 ::  dist_mask(:), onsite_mask(:), calc_mask(:), calcs_mask(:), calcsp_mask(:), param_mask(:,:), calc_mask_for_porbs(:)
@@ -712,7 +712,7 @@ contains
     real(dp), allocatable                ::  intParams(:,:)
 
     nats = size(coord,dim=2)
-    write(*,*)"GET_SKBLOCK_VECT: nats = ",nats,"when atnum = ",atnum
+    !write(*,*)"GET_SKBLOCK_VECT: nats = ",nats,"when atnum = ",atnum
     norbsall = sum(norbs)
     
     blk(:,:)=0.0_dp
@@ -793,7 +793,7 @@ contains
     
     do i = 1,3
        Rab(:,i) = coord(i,:)
-       Rab(:,i) = modulo((Rab(:,i) - coord(i,atnum) + 0.5_dp*lattice_vectors(i,i)),lattice_vectors(i,i)) - 0.5_dp * lattice_vectors(i,i)
+       Rab(:,i) = modulo((Rab(:,i) - refcoord(i) + 0.5_dp*lattice_vectors(i,i)),lattice_vectors(i,i)) - 0.5_dp * lattice_vectors(i,i)
     enddo
 
     dR(:) = norm2(Rab(:,:),dim=2)
@@ -842,7 +842,7 @@ contains
        M = dy_m/dr_m
        N = dz_m/dr_m
        orbidx_sel = pack(orbidx_m,mask=calcs_mask) ! orbidx_m still is the s orbital mask
-       write(*,*)"GET_SKBLOCK_VECT: S atom S orbital calc mask for atom ",atnum,"= ",orbidx_sel
+       !write(*,*)"GET_SKBLOCK_VECT: S atom S orbital calc mask for atom ",atnum,"= ",orbidx_sel
        if(size(orbidx_sel).ne.size(atomidx_m))then
           write(*,*)"GET_SKBLOCK_VECT: size mismatch of orbital and atom index arrays. Abort."
           stop

--- a/src/latte_mods/hsderivative_latte_mod.F90
+++ b/src/latte_mods/hsderivative_latte_mod.F90
@@ -64,16 +64,16 @@ contains
     nats = size(coords,dim=2)
 
     if(bml_get_N(dH0x_bml).LT.0)then
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0x_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0y_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0z_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dH0x_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dH0y_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dH0z_bml)
     else
       call bml_deallocate(dH0x_bml)
       call bml_deallocate(dH0y_bml)
       call bml_deallocate(dH0z_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0x_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0y_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0z_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dH0x_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dH0y_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dH0z_bml)
     endif
 
     ! dH0x = zeros(HDIM,HDIM); dH0y = zeros(HDIM,HDIM); dH0z = zeros(HDIM,HDIM);
@@ -274,16 +274,16 @@ contains
     nats = size(coords,dim=2)
 
     if(bml_get_N(dSx_bml).LT.0)then
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dSx_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dSy_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dSz_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dSx_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dSy_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dSz_bml)
     else
       call bml_deallocate(dSx_bml)
       call bml_deallocate(dSy_bml)
       call bml_deallocate(dSz_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dSx_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dSy_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dSz_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dSx_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dSy_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dSz_bml)
     endif
 
     if (.not.allocated(dSx)) then
@@ -456,46 +456,45 @@ contains
     real(dp), allocatable               ::  intParams1(:,:,:), intParams2(:,:,:)
     real(dp), allocatable               :: dHx_vect(:,:),dHy_vect(:,:),dHz_vect(:,:),ham_vect(:,:)
     integer, allocatable                ::  norbs_atidx(:)
+    logical                             ::  test_accuracy
     ! integer, intent(in)                :: nnstruct(:,:)
 
-
-    write(*,*)"In get_dH ..."
+    test_accuracy = .false.
 
     nats = size(coords,dim=2)
 
     if(bml_get_N(dH0x_bml).LT.0)then
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0x_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0y_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0z_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dH0x_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dH0y_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dH0z_bml)
     else
       call bml_deallocate(dH0x_bml)
       call bml_deallocate(dH0y_bml)
       call bml_deallocate(dH0z_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0x_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0y_bml)
-      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0z_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dH0x_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dH0y_bml)
+      call bml_noinit_matrix(bml_type,bml_element_real,dp,norb,norb,dH0z_bml)
     endif
 
     ! dH0x = zeros(HDIM,HDIM); dH0y = zeros(HDIM,HDIM); dH0z = zeros(HDIM,HDIM);
 
-    if (.not.allocated(dH0x)) then
+    if(test_accuracy)then       
        allocate(dH0x(norb,norb))
-       allocate(dHx_vect(norb,norb))
-       allocate(ham_vect(norb,norb))
-    endif
-    if (.not.allocated(dH0y)) then
        allocate(dH0y(norb,norb))
-       allocate(dHy_vect(norb,norb))
-    endif
-    if (.not.allocated(dH0z)) then
        allocate(dH0z(norb,norb))
-       allocate(dHz_vect(norb,norb))
+       allocate(blockm(maxnorbi,maxnorbi,nats))
+       allocate(blockp(maxnorbi,maxnorbi,nats))
+
+       dH0x = 0.0_dp
+       dH0y = 0.0_dp
+       dH0z = 0.0_dp
     endif
-
-    dH0x = 0.0_dp
-    dH0y = 0.0_dp
-    dH0z = 0.0_dp
-
+    
+    allocate(dHx_vect(norb,norb))
+    allocate(dHy_vect(norb,norb))
+    allocate(dHz_vect(norb,norb))
+    allocate(ham_vect(norb,norb))
+    
     allocate(Rx(nats))
     allocate(Ry(nats))
     allocate(Rz(nats))
@@ -506,151 +505,146 @@ contains
 
     maxnorbi = maxval(norbi)
 
-    if (.not.allocated(blockm)) then
-      allocate(blockm(maxnorbi,maxnorbi,nats))
+    if(.not.allocated(norbs_atidx))then
+       allocate(norbs_atidx(nats))
+       do i=1,nats
+          norbs_atidx(i) = norbi(spindex(i))
+       enddo
     endif
 
-    if (.not.allocated(blockp)) then
-      allocate(blockp(maxnorbi,maxnorbi,nats))
-   endif
-   if(.not.allocated(norbs_atidx))then
-      allocate(norbs_atidx(nats))
-   endif
-    do i=1,nats
-       norbs_atidx(i) = norbi(spindex(i))
-    enddo
+    if(test_accuracy)then
+       !$omp parallel do default(none) private(i) &
+       !$omp private(Rax_p,Rax_m,Ray_p,Ray_m,Raz_p,Raz_m) &
+       !$omp private(dimi,J,Type_pair,dimj,Rb,maxblockij) &
+       !$omp shared(nats,RX,RY,RZ,spindex,hindex,lattice_vectors, dx, threshold) &
+       !$omp shared(norbi,intPairsH,onsitesH,symbol,dH0x_bml,dH0y_bml,dH0z_bml) &
+       !$omp shared(blockm, blockp, dH0x, dH0y, dH0z)
+       do I = 1, nats
 
-    ! !$omp parallel do default(none) private(i) &
-    ! !$omp private(Rax_p,Rax_m,Ray_p,Ray_m,Raz_p,Raz_m) &
-    ! !$omp private(dimi,J,Type_pair,dimj,Rb,maxblockij) &
-    ! !$omp shared(nats,RX,RY,RZ,spindex,hindex,lattice_vectors, dx, threshold) &
-    ! !$omp shared(norbi,intPairsH,onsitesH,symbol,dH0x_bml,dH0y_bml,dH0z_bml) &
-    ! !$omp shared(blockm, blockp, dH0x, dH0y, dH0z)
-    ! do I = 1, nats
+          Type_pair(1) = symbol(i);
+          Rax_p(1) = RX(I)+ dx; Rax_p(2) = RY(I); Rax_p(3) = RZ(I)
+          Rax_m(1) = RX(I)- dx; Rax_m(2) = RY(I); Rax_m(3) = RZ(I)
+          Ray_p(1) = RX(I); Ray_p(2) = RY(I)+dx; Ray_p(3) = RZ(I)
+          Ray_m(1) = RX(I); Ray_m(2) = RY(I)-dx; Ray_m(3) = RZ(I)
+          Raz_p(1) = RX(I); Raz_p(2) = RY(I); Raz_p(3) = RZ(I)+dx
+          Raz_m(1) = RX(I); Raz_m(2) = RY(I); Raz_m(3) = RZ(I)-dx
 
-    !   Type_pair(1) = symbol(i);
-    !   Rax_p(1) = RX(I)+ dx; Rax_p(2) = RY(I); Rax_p(3) = RZ(I)
-    !   Rax_m(1) = RX(I)- dx; Rax_m(2) = RY(I); Rax_m(3) = RZ(I)
-    !   Ray_p(1) = RX(I); Ray_p(2) = RY(I)+dx; Ray_p(3) = RZ(I)
-    !   Ray_m(1) = RX(I); Ray_m(2) = RY(I)-dx; Ray_m(3) = RZ(I)
-    !   Raz_p(1) = RX(I); Raz_p(2) = RY(I); Raz_p(3) = RZ(I)+dx
-    !   Raz_m(1) = RX(I); Raz_m(2) = RY(I); Raz_m(3) = RZ(I)-dx
+          dimi = hindex(2,I)-hindex(1,I)+1;
+          do J = 1,nats
+             if(J .ne. I)then
 
-    !   dimi = hindex(2,I)-hindex(1,I)+1;
-    !   do J = 1,nats
-    !     if(J .ne. I)then
+                Type_pair(2) = symbol(J);
+                Rb(1) = RX(J); Rb(2) = RY(J); Rb(3) = RZ(J)
+                dimj = hindex(2,J)-hindex(1,J)+1;
 
-    !       Type_pair(2) = symbol(J);
-    !       Rb(1) = RX(J); Rb(2) = RY(J); Rb(3) = RZ(J)
-    !       dimj = hindex(2,J)-hindex(1,J)+1;
+                !! MATLAB code
+                !       [fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,Es,Ep,U] = LoadBondIntegralParameters_H(Type_pair); % Used in BondIntegral(dR,fxx_xx)
+                !       diagonal(1:2) = [Es,Ep];
+                !       dh0 = Slater_Koster_Block(IDim,JDim,Rax_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+                !       dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
+                !       dh0 = Slater_Koster_Block(IDim,JDim,Rax_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+                !       dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
 
-    !       !! MATLAB code
-    !       !       [fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,Es,Ep,U] = LoadBondIntegralParameters_H(Type_pair); % Used in BondIntegral(dR,fxx_xx)
-    !       !       diagonal(1:2) = [Es,Ep];
-    !       !       dh0 = Slater_Koster_Block(IDim,JDim,Rax_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
-    !       !       dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
-    !       !       dh0 = Slater_Koster_Block(IDim,JDim,Rax_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
-    !       !       dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
+                call get_SKBlock(spindex(i),spindex(j),Rax_p,&
+                     Rb,lattice_vectors,norbi,&
+                     onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
 
-    !       call get_SKBlock(spindex(i),spindex(j),Rax_p,&
-    !            Rb,lattice_vectors,norbi,&
-    !            onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
+                maxblockij = 0.0_dp
+                do ii=1,dimi
+                   do jj=1,dimj
+                      maxblockij = max(maxblockij,abs(blockp(ii,jj,i)))
+                   enddo
+                enddo
 
-    !       maxblockij = 0.0_dp
-    !       do ii=1,dimi
-    !         do jj=1,dimj
-    !           maxblockij = max(maxblockij,abs(blockp(ii,jj,i)))
-    !         enddo
-    !       enddo
+                if(maxblockij.gt.0.0_dp)then
 
-    !       if(maxblockij.gt.0.0_dp)then
+                   call get_SKBlock(spindex(i),spindex(j),Rax_m,&
+                        Rb,lattice_vectors,norbi,&
+                        onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
 
-    !         call get_SKBlock(spindex(i),spindex(j),Rax_m,&
-    !              Rb,lattice_vectors,norbi,&
-    !              onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
+                   blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
 
-    !         blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
+                   do jj=1,dimj
+                      do ii=1,dimi
+                         dH0x(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
+                      enddo
+                   enddo
 
-    !         do jj=1,dimj
-    !           do ii=1,dimi
-    !             dH0x(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
-    !           enddo
-    !         enddo
+                   !! MATLAB code
+                   !       dh0 = Slater_Koster_Block(IDim,JDim,Ray_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+                   !       dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
+                   !       dh0 = Slater_Koster_Block(IDim,JDim,Ray_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+                   !       dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
 
-    !         !! MATLAB code
-    !         !       dh0 = Slater_Koster_Block(IDim,JDim,Ray_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
-    !         !       dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
-    !         !       dh0 = Slater_Koster_Block(IDim,JDim,Ray_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
-    !         !       dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
+                   call get_SKBlock(spindex(i),spindex(j),Ray_p,&
+                        Rb,lattice_vectors,norbi,&
+                        onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
 
-    !         call get_SKBlock(spindex(i),spindex(j),Ray_p,&
-    !              Rb,lattice_vectors,norbi,&
-    !              onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
+                   call get_SKBlock(spindex(i),spindex(j),Ray_m,&
+                        Rb,lattice_vectors,norbi,&
+                        onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
 
-    !         call get_SKBlock(spindex(i),spindex(j),Ray_m,&
-    !              Rb,lattice_vectors,norbi,&
-    !              onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
+                   blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
 
-    !         blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
+                   do jj=1,dimj
+                      do ii=1,dimi
+                         dH0y(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
+                      enddo
+                   enddo
 
-    !         do jj=1,dimj
-    !           do ii=1,dimi
-    !             dH0y(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
-    !           enddo
-    !         enddo
+                   !! MATLAB code
+                   !       dh0 = Slater_Koster_Block(IDim,JDim,Raz_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+                   !       dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
+                   !       dh0 = Slater_Koster_Block(IDim,JDim,Raz_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+                   !       dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
 
-    !         !! MATLAB code
-    !         !       dh0 = Slater_Koster_Block(IDim,JDim,Raz_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
-    !         !       dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
-    !         !       dh0 = Slater_Koster_Block(IDim,JDim,Raz_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
-    !         !       dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
+                   call get_SKBlock(spindex(i),spindex(j),Raz_p,&
+                        Rb,lattice_vectors,norbi,&
+                        onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
 
-    !         call get_SKBlock(spindex(i),spindex(j),Raz_p,&
-    !              Rb,lattice_vectors,norbi,&
-    !              onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
+                   call get_SKBlock(spindex(i),spindex(j),Raz_m,&
+                        Rb,lattice_vectors,norbi,&
+                        onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
 
-    !         call get_SKBlock(spindex(i),spindex(j),Raz_m,&
-    !              Rb,lattice_vectors,norbi,&
-    !              onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
+                   blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
 
-    !         blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
+                   do jj=1,dimj
+                      do ii=1,dimi
+                         dH0z(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
+                      enddo
+                   enddo
 
-    !         do jj=1,dimj
-    !           do ii=1,dimi
-    !             dH0z(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
-    !           enddo
-    !         enddo
-
-    !       endif
-    !     endif
-    !   enddo
-    ! enddo
-    ! !$omp end parallel do
-    
-    allocate(intParams1(nats,16,4))
-    allocate(intParams2(nats,16,4))
-
-    !$omp parallel do default(none) private(i) &
-    !$omp private(Rax_p,Rax_m,Ray_p,Ray_m,Raz_p,Raz_m) &
-    !$omp private(dimi,J,Type_pair,dimj,Rb,maxblockij) &
-    !$omp private(intParams1, intParams2) &
-    !$omp shared(nats,RX,RY,RZ,spindex,hindex,lattice_vectors, dx, threshold) &
-    !$omp shared(norbs_atidx,intPairsH,onsitesH,symbol,dH0x_bml,dH0y_bml,dH0z_bml) &
-    !$omp shared(coords,ham_vect) &
-    !$omp shared(blockm, blockp, dHx_vect, dHy_vect, dHz_vect)
-    do I = 1, nats
-       do j = 1,nats
-          intParams1(j,:,:) = intPairsH(spindex(i),spindex(j))%intParams(:,1:4)
-          intParams2(j,:,:) = intPairsH(spindex(j),spindex(i))%intParams(:,1:4)
+                endif
+             endif
+          enddo
        enddo
+       !$omp end parallel do
+   endif
+    
+   allocate(intParams1(nats,16,4))
+   allocate(intParams2(nats,16,4))
 
+   !$omp parallel do default(none) private(i) &
+   !$omp private(Rax_p,Rax_m,Ray_p,Ray_m,Raz_p,Raz_m) &
+   !$omp private(J) &
+   !$omp private(intParams1, intParams2) &
+   !$omp shared(nats,RX,RY,RZ,spindex,hindex,lattice_vectors, dx, threshold) &
+   !$omp shared(norbs_atidx,intPairsH,onsitesH) &
+   !$omp shared(coords,ham_vect) &
+   !$omp shared(dHx_vect, dHy_vect, dHz_vect)
+   do I = 1, nats
+      do j = 1,nats
+         intParams1(j,:,:) = intPairsH(spindex(i),spindex(j))%intParams(:,1:4)
+         intParams2(j,:,:) = intPairsH(spindex(j),spindex(i))%intParams(:,1:4)
+      enddo
+      
       Rax_p(1) = RX(I)+ dx; Rax_p(2) = RY(I); Rax_p(3) = RZ(I)
       Rax_m(1) = RX(I)- dx; Rax_m(2) = RY(I); Rax_m(3) = RZ(I)
       Ray_p(1) = RX(I); Ray_p(2) = RY(I)+dx; Ray_p(3) = RZ(I)
       Ray_m(1) = RX(I); Ray_m(2) = RY(I)-dx; Ray_m(3) = RZ(I)
       Raz_p(1) = RX(I); Raz_p(2) = RY(I); Raz_p(3) = RZ(I)+dx
       Raz_m(1) = RX(I); Raz_m(2) = RY(I); Raz_m(3) = RZ(I)-dx
-
+      
       call get_SKBlock_vect(spindex,rax_p,coords(:,:),lattice_vectors,norbs_atidx,&
            onsitesH,intParams1(:,:,:),intParams2(:,:,:),dHx_vect(hindex(1,i):hindex(2,i),:),i)
 
@@ -679,36 +673,36 @@ contains
            - ham_vect(hindex(1,i):hindex(2,i),:))/(2.0_dp*dx)
    enddo
    
-    !$omp end parallel do
+   !$omp end parallel do
 
-   ! if(.not.all(abs(dHx_vect-dH0x).lt.1.D-9))then
-   !     do i = 1,norb
-   !        do j = 1,norb
-   !           if(abs(dHx_vect(i,j)-dH0x(i,j)).ge.1.D-9)then
-   !              write(*,*)"GET_DH_OR_DS_VECT: Vectorized dHx differs at i,j = ",i,j,"with difference ",dHx_vect(i,j)-dH0x(i,j)
-   !           endif
-   !        enddo
-   !     enddo
-   !  endif
+   if(test_accuracy)then
+      if(.not.all(abs(dHx_vect-dH0x).lt.1.D-9))then
+         do i = 1,norb
+            do j = 1,norb
+               if(abs(dHx_vect(i,j)-dH0x(i,j)).ge.1.D-9)then
+                  write(*,*)"GET_DH_OR_DS_VECT: Vectorized dHx differs at i,j = ",i,j,"with difference ",dHx_vect(i,j)-dH0x(i,j)
+               endif
+            enddo
+         enddo
+      endif
+   endif
 
-    call bml_import_from_dense(bml_type,dHx_vect,dH0x_bml,threshold,norb) !Dense to dense_bml
-    call bml_import_from_dense(bml_type,dHy_vect,dH0y_bml,threshold,norb) !Dense to dense_bml
-    call bml_import_from_dense(bml_type,dHz_vect,dH0z_bml,threshold,norb) !Dense to dense_bml
-
-    if (allocated(dH0x)) then
-       deallocate(dH0x)
-       deallocate(dHx_vect)
-       deallocate(ham_vect)
-       deallocate(norbs_atidx)
-    endif
-    if (allocated(dH0y)) then
-       deallocate(dH0y)
-       deallocate(dHy_vect)
-    endif
-    if (allocated(dH0z)) then
-       deallocate(dH0z)
-       deallocate(dHz_vect)
-    endif
+   call bml_import_from_dense(bml_type,dHx_vect,dH0x_bml,threshold,norb) !Dense to dense_bml
+   call bml_import_from_dense(bml_type,dHy_vect,dH0y_bml,threshold,norb) !Dense to dense_bml
+   call bml_import_from_dense(bml_type,dHz_vect,dH0z_bml,threshold,norb) !Dense to dense_bml
+   
+   if (allocated(dH0x)) then
+      deallocate(dH0x)
+      deallocate(dH0y)
+      deallocate(dH0z)
+      deallocate(blockm)
+      deallocate(blockp)
+   endif
+    
+   deallocate(dHx_vect)
+   deallocate(dHy_vect)
+   deallocate(dHz_vect)
+   deallocate(ham_vect)
 
     ! stop
   end subroutine get_dH_or_dS_vect

--- a/src/latte_mods/hsderivative_latte_mod.F90
+++ b/src/latte_mods/hsderivative_latte_mod.F90
@@ -520,112 +520,112 @@ contains
        norbs_atidx(i) = norbi(spindex(i))
     enddo
 
-    !$omp parallel do default(none) private(i) &
-    !$omp private(Rax_p,Rax_m,Ray_p,Ray_m,Raz_p,Raz_m) &
-    !$omp private(dimi,J,Type_pair,dimj,Rb,maxblockij) &
-    !$omp shared(nats,RX,RY,RZ,spindex,hindex,lattice_vectors, dx, threshold) &
-    !$omp shared(norbi,intPairsH,onsitesH,symbol,dH0x_bml,dH0y_bml,dH0z_bml) &
-    !$omp shared(blockm, blockp, dH0x, dH0y, dH0z)
-    do I = 1, nats
+    ! !$omp parallel do default(none) private(i) &
+    ! !$omp private(Rax_p,Rax_m,Ray_p,Ray_m,Raz_p,Raz_m) &
+    ! !$omp private(dimi,J,Type_pair,dimj,Rb,maxblockij) &
+    ! !$omp shared(nats,RX,RY,RZ,spindex,hindex,lattice_vectors, dx, threshold) &
+    ! !$omp shared(norbi,intPairsH,onsitesH,symbol,dH0x_bml,dH0y_bml,dH0z_bml) &
+    ! !$omp shared(blockm, blockp, dH0x, dH0y, dH0z)
+    ! do I = 1, nats
 
-      Type_pair(1) = symbol(i);
-      Rax_p(1) = RX(I)+ dx; Rax_p(2) = RY(I); Rax_p(3) = RZ(I)
-      Rax_m(1) = RX(I)- dx; Rax_m(2) = RY(I); Rax_m(3) = RZ(I)
-      Ray_p(1) = RX(I); Ray_p(2) = RY(I)+dx; Ray_p(3) = RZ(I)
-      Ray_m(1) = RX(I); Ray_m(2) = RY(I)-dx; Ray_m(3) = RZ(I)
-      Raz_p(1) = RX(I); Raz_p(2) = RY(I); Raz_p(3) = RZ(I)+dx
-      Raz_m(1) = RX(I); Raz_m(2) = RY(I); Raz_m(3) = RZ(I)-dx
+    !   Type_pair(1) = symbol(i);
+    !   Rax_p(1) = RX(I)+ dx; Rax_p(2) = RY(I); Rax_p(3) = RZ(I)
+    !   Rax_m(1) = RX(I)- dx; Rax_m(2) = RY(I); Rax_m(3) = RZ(I)
+    !   Ray_p(1) = RX(I); Ray_p(2) = RY(I)+dx; Ray_p(3) = RZ(I)
+    !   Ray_m(1) = RX(I); Ray_m(2) = RY(I)-dx; Ray_m(3) = RZ(I)
+    !   Raz_p(1) = RX(I); Raz_p(2) = RY(I); Raz_p(3) = RZ(I)+dx
+    !   Raz_m(1) = RX(I); Raz_m(2) = RY(I); Raz_m(3) = RZ(I)-dx
 
-      dimi = hindex(2,I)-hindex(1,I)+1;
-      do J = 1,nats
-        if(J .ne. I)then
+    !   dimi = hindex(2,I)-hindex(1,I)+1;
+    !   do J = 1,nats
+    !     if(J .ne. I)then
 
-          Type_pair(2) = symbol(J);
-          Rb(1) = RX(J); Rb(2) = RY(J); Rb(3) = RZ(J)
-          dimj = hindex(2,J)-hindex(1,J)+1;
+    !       Type_pair(2) = symbol(J);
+    !       Rb(1) = RX(J); Rb(2) = RY(J); Rb(3) = RZ(J)
+    !       dimj = hindex(2,J)-hindex(1,J)+1;
 
-          !! MATLAB code
-          !       [fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,Es,Ep,U] = LoadBondIntegralParameters_H(Type_pair); % Used in BondIntegral(dR,fxx_xx)
-          !       diagonal(1:2) = [Es,Ep];
-          !       dh0 = Slater_Koster_Block(IDim,JDim,Rax_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
-          !       dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
-          !       dh0 = Slater_Koster_Block(IDim,JDim,Rax_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
-          !       dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
+    !       !! MATLAB code
+    !       !       [fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,Es,Ep,U] = LoadBondIntegralParameters_H(Type_pair); % Used in BondIntegral(dR,fxx_xx)
+    !       !       diagonal(1:2) = [Es,Ep];
+    !       !       dh0 = Slater_Koster_Block(IDim,JDim,Rax_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+    !       !       dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
+    !       !       dh0 = Slater_Koster_Block(IDim,JDim,Rax_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+    !       !       dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
 
-          call get_SKBlock(spindex(i),spindex(j),Rax_p,&
-               Rb,lattice_vectors,norbi,&
-               onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
+    !       call get_SKBlock(spindex(i),spindex(j),Rax_p,&
+    !            Rb,lattice_vectors,norbi,&
+    !            onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
 
-          maxblockij = 0.0_dp
-          do ii=1,dimi
-            do jj=1,dimj
-              maxblockij = max(maxblockij,abs(blockp(ii,jj,i)))
-            enddo
-          enddo
+    !       maxblockij = 0.0_dp
+    !       do ii=1,dimi
+    !         do jj=1,dimj
+    !           maxblockij = max(maxblockij,abs(blockp(ii,jj,i)))
+    !         enddo
+    !       enddo
 
-          if(maxblockij.gt.0.0_dp)then
+    !       if(maxblockij.gt.0.0_dp)then
 
-            call get_SKBlock(spindex(i),spindex(j),Rax_m,&
-                 Rb,lattice_vectors,norbi,&
-                 onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
+    !         call get_SKBlock(spindex(i),spindex(j),Rax_m,&
+    !              Rb,lattice_vectors,norbi,&
+    !              onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
 
-            blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
+    !         blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
 
-            do jj=1,dimj
-              do ii=1,dimi
-                dH0x(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
-              enddo
-            enddo
+    !         do jj=1,dimj
+    !           do ii=1,dimi
+    !             dH0x(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
+    !           enddo
+    !         enddo
 
-            !! MATLAB code
-            !       dh0 = Slater_Koster_Block(IDim,JDim,Ray_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
-            !       dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
-            !       dh0 = Slater_Koster_Block(IDim,JDim,Ray_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
-            !       dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
+    !         !! MATLAB code
+    !         !       dh0 = Slater_Koster_Block(IDim,JDim,Ray_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+    !         !       dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
+    !         !       dh0 = Slater_Koster_Block(IDim,JDim,Ray_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+    !         !       dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
 
-            call get_SKBlock(spindex(i),spindex(j),Ray_p,&
-                 Rb,lattice_vectors,norbi,&
-                 onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
+    !         call get_SKBlock(spindex(i),spindex(j),Ray_p,&
+    !              Rb,lattice_vectors,norbi,&
+    !              onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
 
-            call get_SKBlock(spindex(i),spindex(j),Ray_m,&
-                 Rb,lattice_vectors,norbi,&
-                 onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
+    !         call get_SKBlock(spindex(i),spindex(j),Ray_m,&
+    !              Rb,lattice_vectors,norbi,&
+    !              onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
 
-            blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
+    !         blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
 
-            do jj=1,dimj
-              do ii=1,dimi
-                dH0y(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
-              enddo
-            enddo
+    !         do jj=1,dimj
+    !           do ii=1,dimi
+    !             dH0y(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
+    !           enddo
+    !         enddo
 
-            !! MATLAB code
-            !       dh0 = Slater_Koster_Block(IDim,JDim,Raz_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
-            !       dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
-            !       dh0 = Slater_Koster_Block(IDim,JDim,Raz_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
-            !       dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
+    !         !! MATLAB code
+    !         !       dh0 = Slater_Koster_Block(IDim,JDim,Raz_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+    !         !       dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
+    !         !       dh0 = Slater_Koster_Block(IDim,JDim,Raz_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+    !         !       dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
 
-            call get_SKBlock(spindex(i),spindex(j),Raz_p,&
-                 Rb,lattice_vectors,norbi,&
-                 onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
+    !         call get_SKBlock(spindex(i),spindex(j),Raz_p,&
+    !              Rb,lattice_vectors,norbi,&
+    !              onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
 
-            call get_SKBlock(spindex(i),spindex(j),Raz_m,&
-                 Rb,lattice_vectors,norbi,&
-                 onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
+    !         call get_SKBlock(spindex(i),spindex(j),Raz_m,&
+    !              Rb,lattice_vectors,norbi,&
+    !              onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
 
-            blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
+    !         blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
 
-            do jj=1,dimj
-              do ii=1,dimi
-                dH0z(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
-              enddo
-            enddo
+    !         do jj=1,dimj
+    !           do ii=1,dimi
+    !             dH0z(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
+    !           enddo
+    !         enddo
 
-          endif
-        endif
-      enddo
-    enddo
-    !$omp end parallel do
+    !       endif
+    !     endif
+    !   enddo
+    ! enddo
+    ! !$omp end parallel do
     
     allocate(intParams1(nats,16,4))
     allocate(intParams2(nats,16,4))
@@ -633,9 +633,10 @@ contains
     !$omp parallel do default(none) private(i) &
     !$omp private(Rax_p,Rax_m,Ray_p,Ray_m,Raz_p,Raz_m) &
     !$omp private(dimi,J,Type_pair,dimj,Rb,maxblockij) &
+    !$omp private(intParams1, intParams2) &
     !$omp shared(nats,RX,RY,RZ,spindex,hindex,lattice_vectors, dx, threshold) &
     !$omp shared(norbs_atidx,intPairsH,onsitesH,symbol,dH0x_bml,dH0y_bml,dH0z_bml) &
-    !$omp shared(intParams1,intParams2,coords,ham_vect) &
+    !$omp shared(coords,ham_vect) &
     !$omp shared(blockm, blockp, dHx_vect, dHy_vect, dHz_vect)
     do I = 1, nats
        do j = 1,nats
@@ -680,19 +681,19 @@ contains
    
     !$omp end parallel do
 
-   if(.not.all(abs(dHx_vect-dH0x).lt.1.D-12))then
-       do i = 1,norb
-          do j = 1,norb
-             if(abs(dHx_vect(i,j)-dH0x(i,j)).ge.1.D-12)then
-                write(*,*)"GET_DH_OR_DS_VECT: Vectorized dHx differs at i,j = ",i,j,"with difference ",dHx_vect(i,j)-dH0x(i,j)
-             endif
-          enddo
-       enddo
-    endif
+   ! if(.not.all(abs(dHx_vect-dH0x).lt.1.D-9))then
+   !     do i = 1,norb
+   !        do j = 1,norb
+   !           if(abs(dHx_vect(i,j)-dH0x(i,j)).ge.1.D-9)then
+   !              write(*,*)"GET_DH_OR_DS_VECT: Vectorized dHx differs at i,j = ",i,j,"with difference ",dHx_vect(i,j)-dH0x(i,j)
+   !           endif
+   !        enddo
+   !     enddo
+   !  endif
 
-    call bml_import_from_dense(bml_type,dH0x,dH0x_bml,threshold,norb) !Dense to dense_bml
-    call bml_import_from_dense(bml_type,dH0y,dH0y_bml,threshold,norb) !Dense to dense_bml
-    call bml_import_from_dense(bml_type,dH0z,dH0z_bml,threshold,norb) !Dense to dense_bml
+    call bml_import_from_dense(bml_type,dHx_vect,dH0x_bml,threshold,norb) !Dense to dense_bml
+    call bml_import_from_dense(bml_type,dHy_vect,dH0y_bml,threshold,norb) !Dense to dense_bml
+    call bml_import_from_dense(bml_type,dHz_vect,dH0z_bml,threshold,norb) !Dense to dense_bml
 
     if (allocated(dH0x)) then
        deallocate(dH0x)

--- a/src/latte_mods/hsderivative_latte_mod.F90
+++ b/src/latte_mods/hsderivative_latte_mod.F90
@@ -17,7 +17,7 @@ module hsderivative_latte_mod
 
   integer, parameter :: dp = kind(1.0d0)
 
-  public :: get_dH, get_dS
+  public :: get_dH, get_dS, get_dH_or_dS_vect
 
 contains
 
@@ -417,5 +417,299 @@ contains
     endif
 
   end subroutine get_dS
+
+    !> This routine computes the derivative of H matrix.
+  !! \param dx X differential to compute the derivatives
+  !! \param coords System coordinates.
+  !! \param hindex Contains the Hamiltonian indices for every atom (see get_hindex).
+  !! \param spindex Species indices (see system_type).
+  !! \param intPairsH See defprg_inition in intPairs_type
+  !! \param onsitesH Onsite energies for every orbital of a particular species.
+  !! \param symbol System element symbol.
+  !! \param lattice_vectors System lattece vectors.
+  !! \param norb Number of total orbitals.
+  !! \param norbi Number of orbitals for each atomic site.
+  !! \param threshold Threshold value for matrix elements.
+  !! \param dH0x_bml x derivative of H0.
+  !! \param dH0y_bml y derivative of H0.
+  !! \param dH0z_bml z derivative of H0.
+  !!
+  subroutine get_dH_or_dS_vect(dx,coords,hindex,spindex,intPairsH,onsitesH,symbol,lattice_vectors, norb, norbi, bml_type, &
+       threshold, dH0x_bml,dH0y_bml,dH0z_bml)
+    implicit none
+    character(2)                       ::  Type_pair(2)
+    character(2), intent(in)           ::  symbol(:)
+    character(len=*), intent(in)       ::  bml_type
+    integer                            ::  IDim, JDim, nats, dimi
+    integer                            ::  dimj, i, ii, j
+    integer                            ::  jj, l
+    integer, intent(in)                ::  hindex(:,:), norb, norbi(:), spindex(:)
+    integer                            ::  maxnorbi
+    real(dp)                           ::  Rax_m(3), Rax_p(3), Ray_m(3), Ray_p(3)
+    real(dp)                           ::  Raz_m(3), Raz_p(3), Rb(3), d, maxblockij
+    real(dp), allocatable              ::  Rx(:), Ry(:), Rz(:), blockm(:,:,:)
+    real(dp), allocatable              ::  blockp(:,:,:), dh0(:,:), dH0x(:,:), dH0y(:,:), dH0z(:,:)
+    real(dp), intent(in)               ::  coords(:,:), dx, lattice_vectors(:,:), onsitesH(:,:)
+    real(dp), intent(in)               ::  threshold
+    type(bml_matrix_t), intent(inout)  ::  dH0x_bml, dH0y_bml, dH0z_bml
+    type(intpairs_type), intent(in)  ::  intPairsH(:,:)
+    real(dp), allocatable               ::  intParams1(:,:,:), intParams2(:,:,:)
+    real(dp), allocatable               :: dHx_vect(:,:),dHy_vect(:,:),dHz_vect(:,:),ham_vect(:,:)
+    integer, allocatable                ::  norbs_atidx(:)
+    ! integer, intent(in)                :: nnstruct(:,:)
+
+
+    write(*,*)"In get_dH ..."
+
+    nats = size(coords,dim=2)
+
+    if(bml_get_N(dH0x_bml).LT.0)then
+      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0x_bml)
+      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0y_bml)
+      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0z_bml)
+    else
+      call bml_deallocate(dH0x_bml)
+      call bml_deallocate(dH0y_bml)
+      call bml_deallocate(dH0z_bml)
+      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0x_bml)
+      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0y_bml)
+      call bml_zero_matrix(bml_type,bml_element_real,dp,norb,norb,dH0z_bml)
+    endif
+
+    ! dH0x = zeros(HDIM,HDIM); dH0y = zeros(HDIM,HDIM); dH0z = zeros(HDIM,HDIM);
+
+    if (.not.allocated(dH0x)) then
+       allocate(dH0x(norb,norb))
+       allocate(dHx_vect(norb,norb))
+       allocate(ham_vect(norb,norb))
+    endif
+    if (.not.allocated(dH0y)) then
+       allocate(dH0y(norb,norb))
+       allocate(dHy_vect(norb,norb))
+    endif
+    if (.not.allocated(dH0z)) then
+       allocate(dH0z(norb,norb))
+       allocate(dHz_vect(norb,norb))
+    endif
+
+    dH0x = 0.0_dp
+    dH0y = 0.0_dp
+    dH0z = 0.0_dp
+
+    allocate(Rx(nats))
+    allocate(Ry(nats))
+    allocate(Rz(nats))
+
+    Rx = coords(1,:)
+    Ry = coords(2,:)
+    Rz = coords(3,:)
+
+    maxnorbi = maxval(norbi)
+
+    if (.not.allocated(blockm)) then
+      allocate(blockm(maxnorbi,maxnorbi,nats))
+    endif
+
+    if (.not.allocated(blockp)) then
+      allocate(blockp(maxnorbi,maxnorbi,nats))
+   endif
+   if(.not.allocated(norbs_atidx))then
+      allocate(norbs_atidx(nats))
+   endif
+    do i=1,nats
+       norbs_atidx(i) = norbi(spindex(i))
+    enddo
+
+    !$omp parallel do default(none) private(i) &
+    !$omp private(Rax_p,Rax_m,Ray_p,Ray_m,Raz_p,Raz_m) &
+    !$omp private(dimi,J,Type_pair,dimj,Rb,maxblockij) &
+    !$omp shared(nats,RX,RY,RZ,spindex,hindex,lattice_vectors, dx, threshold) &
+    !$omp shared(norbi,intPairsH,onsitesH,symbol,dH0x_bml,dH0y_bml,dH0z_bml) &
+    !$omp shared(blockm, blockp, dH0x, dH0y, dH0z)
+    do I = 1, nats
+
+      Type_pair(1) = symbol(i);
+      Rax_p(1) = RX(I)+ dx; Rax_p(2) = RY(I); Rax_p(3) = RZ(I)
+      Rax_m(1) = RX(I)- dx; Rax_m(2) = RY(I); Rax_m(3) = RZ(I)
+      Ray_p(1) = RX(I); Ray_p(2) = RY(I)+dx; Ray_p(3) = RZ(I)
+      Ray_m(1) = RX(I); Ray_m(2) = RY(I)-dx; Ray_m(3) = RZ(I)
+      Raz_p(1) = RX(I); Raz_p(2) = RY(I); Raz_p(3) = RZ(I)+dx
+      Raz_m(1) = RX(I); Raz_m(2) = RY(I); Raz_m(3) = RZ(I)-dx
+
+      dimi = hindex(2,I)-hindex(1,I)+1;
+      do J = 1,nats
+        if(J .ne. I)then
+
+          Type_pair(2) = symbol(J);
+          Rb(1) = RX(J); Rb(2) = RY(J); Rb(3) = RZ(J)
+          dimj = hindex(2,J)-hindex(1,J)+1;
+
+          !! MATLAB code
+          !       [fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,Es,Ep,U] = LoadBondIntegralParameters_H(Type_pair); % Used in BondIntegral(dR,fxx_xx)
+          !       diagonal(1:2) = [Es,Ep];
+          !       dh0 = Slater_Koster_Block(IDim,JDim,Rax_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+          !       dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
+          !       dh0 = Slater_Koster_Block(IDim,JDim,Rax_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+          !       dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0x(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
+
+          call get_SKBlock(spindex(i),spindex(j),Rax_p,&
+               Rb,lattice_vectors,norbi,&
+               onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
+
+          maxblockij = 0.0_dp
+          do ii=1,dimi
+            do jj=1,dimj
+              maxblockij = max(maxblockij,abs(blockp(ii,jj,i)))
+            enddo
+          enddo
+
+          if(maxblockij.gt.0.0_dp)then
+
+            call get_SKBlock(spindex(i),spindex(j),Rax_m,&
+                 Rb,lattice_vectors,norbi,&
+                 onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
+
+            blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
+
+            do jj=1,dimj
+              do ii=1,dimi
+                dH0x(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
+              enddo
+            enddo
+
+            !! MATLAB code
+            !       dh0 = Slater_Koster_Block(IDim,JDim,Ray_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+            !       dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
+            !       dh0 = Slater_Koster_Block(IDim,JDim,Ray_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+            !       dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0y(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
+
+            call get_SKBlock(spindex(i),spindex(j),Ray_p,&
+                 Rb,lattice_vectors,norbi,&
+                 onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
+
+            call get_SKBlock(spindex(i),spindex(j),Ray_m,&
+                 Rb,lattice_vectors,norbi,&
+                 onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
+
+            blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
+
+            do jj=1,dimj
+              do ii=1,dimi
+                dH0y(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
+              enddo
+            enddo
+
+            !! MATLAB code
+            !       dh0 = Slater_Koster_Block(IDim,JDim,Raz_p,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+            !       dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) + dh0/(2*dx);
+            !       dh0 = Slater_Koster_Block(IDim,JDim,Raz_m,Rb,LBox,Type_pair,fss_sigma,fsp_sigma,fpp_sigma,fpp_pi,diagonal);
+            !       dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J))  = dH0z(H_INDEX_START(I):H_INDEX_END(I),H_INDEX_START(J):H_INDEX_END(J)) - dh0/(2*dx);
+
+            call get_SKBlock(spindex(i),spindex(j),Raz_p,&
+                 Rb,lattice_vectors,norbi,&
+                 onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockp,i)
+
+            call get_SKBlock(spindex(i),spindex(j),Raz_m,&
+                 Rb,lattice_vectors,norbi,&
+                 onsitesH,intPairsH(spindex(i),spindex(j))%intParams,intPairsH(spindex(j),spindex(i))%intParams,blockm,i)
+
+            blockp(:,:,i) = (blockp(:,:,i) - blockm(:,:,i))/(2.0_dp*dx)
+
+            do jj=1,dimj
+              do ii=1,dimi
+                dH0z(hindex(1,i)-1+ii,hindex(1,j)-1+jj) = blockp(ii,jj,i)
+              enddo
+            enddo
+
+          endif
+        endif
+      enddo
+    enddo
+    !$omp end parallel do
+    
+    allocate(intParams1(nats,16,4))
+    allocate(intParams2(nats,16,4))
+
+    !$omp parallel do default(none) private(i) &
+    !$omp private(Rax_p,Rax_m,Ray_p,Ray_m,Raz_p,Raz_m) &
+    !$omp private(dimi,J,Type_pair,dimj,Rb,maxblockij) &
+    !$omp shared(nats,RX,RY,RZ,spindex,hindex,lattice_vectors, dx, threshold) &
+    !$omp shared(norbs_atidx,intPairsH,onsitesH,symbol,dH0x_bml,dH0y_bml,dH0z_bml) &
+    !$omp shared(intParams1,intParams2,coords,ham_vect) &
+    !$omp shared(blockm, blockp, dHx_vect, dHy_vect, dHz_vect)
+    do I = 1, nats
+       do j = 1,nats
+          intParams1(j,:,:) = intPairsH(spindex(i),spindex(j))%intParams(:,1:4)
+          intParams2(j,:,:) = intPairsH(spindex(j),spindex(i))%intParams(:,1:4)
+       enddo
+
+      Rax_p(1) = RX(I)+ dx; Rax_p(2) = RY(I); Rax_p(3) = RZ(I)
+      Rax_m(1) = RX(I)- dx; Rax_m(2) = RY(I); Rax_m(3) = RZ(I)
+      Ray_p(1) = RX(I); Ray_p(2) = RY(I)+dx; Ray_p(3) = RZ(I)
+      Ray_m(1) = RX(I); Ray_m(2) = RY(I)-dx; Ray_m(3) = RZ(I)
+      Raz_p(1) = RX(I); Raz_p(2) = RY(I); Raz_p(3) = RZ(I)+dx
+      Raz_m(1) = RX(I); Raz_m(2) = RY(I); Raz_m(3) = RZ(I)-dx
+
+      call get_SKBlock_vect(spindex,rax_p,coords(:,:),lattice_vectors,norbs_atidx,&
+           onsitesH,intParams1(:,:,:),intParams2(:,:,:),dHx_vect(hindex(1,i):hindex(2,i),:),i)
+
+      call get_SKBlock_vect(spindex,rax_m,coords(:,:),lattice_vectors,norbs_atidx,&
+           onsitesH,intParams1(:,:,:),intParams2(:,:,:),ham_vect(hindex(1,i):hindex(2,i),:),i)
+
+      dHx_vect(hindex(1,i):hindex(2,i),:) = (dHx_vect(hindex(1,i):hindex(2,i),:) &
+           - ham_vect(hindex(1,i):hindex(2,i),:))/(2.0_dp*dx)
+
+      call get_SKBlock_vect(spindex,ray_p,coords(:,:),lattice_vectors,norbs_atidx,&
+           onsitesH,intParams1(:,:,:),intParams2(:,:,:),dHy_vect(hindex(1,i):hindex(2,i),:),i)
+
+      call get_SKBlock_vect(spindex,ray_m,coords(:,:),lattice_vectors,norbs_atidx,&
+           onsitesH,intParams1(:,:,:),intParams2(:,:,:),ham_vect(hindex(1,i):hindex(2,i),:),i)
+
+      dHy_vect(hindex(1,i):hindex(2,i),:) = (dHy_vect(hindex(1,i):hindex(2,i),:) &
+           - ham_vect(hindex(1,i):hindex(2,i),:))/(2.0_dp*dx)
+
+      call get_SKBlock_vect(spindex,raz_p,coords(:,:),lattice_vectors,norbs_atidx,&
+           onsitesH,intParams1(:,:,:),intParams2(:,:,:),dHz_vect(hindex(1,i):hindex(2,i),:),i)
+
+      call get_SKBlock_vect(spindex,raz_m,coords(:,:),lattice_vectors,norbs_atidx,&
+           onsitesH,intParams1(:,:,:),intParams2(:,:,:),ham_vect(hindex(1,i):hindex(2,i),:),i)
+
+      dHz_vect(hindex(1,i):hindex(2,i),:) = (dHz_vect(hindex(1,i):hindex(2,i),:) &
+           - ham_vect(hindex(1,i):hindex(2,i),:))/(2.0_dp*dx)
+   enddo
+   
+    !$omp end parallel do
+
+   if(.not.all(abs(dHx_vect-dH0x).lt.1.D-12))then
+       do i = 1,norb
+          do j = 1,norb
+             if(abs(dHx_vect(i,j)-dH0x(i,j)).ge.1.D-12)then
+                write(*,*)"GET_DH_OR_DS_VECT: Vectorized dHx differs at i,j = ",i,j,"with difference ",dHx_vect(i,j)-dH0x(i,j)
+             endif
+          enddo
+       enddo
+    endif
+
+    call bml_import_from_dense(bml_type,dH0x,dH0x_bml,threshold,norb) !Dense to dense_bml
+    call bml_import_from_dense(bml_type,dH0y,dH0y_bml,threshold,norb) !Dense to dense_bml
+    call bml_import_from_dense(bml_type,dH0z,dH0z_bml,threshold,norb) !Dense to dense_bml
+
+    if (allocated(dH0x)) then
+       deallocate(dH0x)
+       deallocate(dHx_vect)
+       deallocate(ham_vect)
+       deallocate(norbs_atidx)
+    endif
+    if (allocated(dH0y)) then
+       deallocate(dH0y)
+       deallocate(dHy_vect)
+    endif
+    if (allocated(dH0z)) then
+       deallocate(dH0z)
+       deallocate(dHz_vect)
+    endif
+
+    ! stop
+  end subroutine get_dH_or_dS_vect
 
 end module hsderivative_latte_mod


### PR DESCRIPTION
o Add bondIntegral_vect() with vectorized calculation of integrals from parameters
o Add new get_SKBlock_vect() with vectorized calculation of matrix elements
  - Calculates entire rows of matrix elements
  - Uses Fortran masking methods to select matrix elements corresponding to specific orbital combinations
  - Vectorized calculations for each orbital combination
o Add new get_hsmat_vect() to use get_SKBlock_vect() for H or S calculation
  - Currently includes code to calculate with or without vectorization and check for agreement
o Add new get_dH_or_dS_vect() to use get_SKBlock_vect() for dH or dS calculation
  - Currently includes code to calculate with or without vectorization and check for agreement
o Do some clean up of previous get_SKBlock() code

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/qmd-progress/295)
<!-- Reviewable:end -->
