### PR TITLE
Add option to rescale restart velocities

### DIFF
--- a/examples/gpmdk/src/gpmdcov_mdloop.F90
+++ b/examples/gpmdk/src/gpmdcov_mdloop.F90
@@ -136,6 +136,12 @@ contains
 
       !! Statistical temperature in Kelvin
       Temp = (2.0_dp/3.0_dp)*KE2T*EKIN/real(sy%nats,dp);
+      if(gpmdt%rescale_restart_vel.and.gpmdt%restartfromdump.and.(mdstep-gpmdt%minimization_steps).eq.1)then
+         write(*,*)"GOMDCOV_MDLOOP: Rescaling the restart velocities to ",gpmdt%temp0," Kelvin (expected to relax due to equipartition)"
+         EKIN = EKIN * gpmdt%temp0/Temp
+         sy%velocity = sy%velocity * sqrt(gpmdt%temp0/Temp)
+         Temp = gpmdt%temp0
+      endif
       !! Total Energy in eV
       Energy = EKIN + EPOT;
       !! Time in fs

--- a/examples/gpmdk/src/gpmdcov_parser.F90
+++ b/examples/gpmdk/src/gpmdcov_parser.F90
@@ -177,6 +177,9 @@ module gpmdcov_parser_mod
 
     !> Perform initial graph annealing with dt=0
     logical :: anneal_graph
+
+    !> Rescale velocities from restart file to match initial temperature
+    logical :: rescale_restart_vel
     
   end type gpmd_type
 
@@ -240,7 +243,7 @@ contains
     implicit none 
     character(len=*), intent(in) :: filename
     type(gpmd_type), intent(inout) :: gpmdt
-    integer, parameter :: nkey_char = 6, nkey_int = 15, nkey_re = 7, nkey_log = 21
+    integer, parameter :: nkey_char = 6, nkey_int = 15, nkey_re = 7, nkey_log = 22
     integer :: i
     real(dp) :: realtmp
     character(20) :: dummyc
@@ -272,11 +275,11 @@ contains
          &'ComputeCurrents=', 'TranslateAndFoldToBox=', 'UseVectSKBlock=', 'ApplyVoltage=','XLBO=',&
          'CoarseQMD=',&
          &'UseDispersion=','UseFreeze=','SymmetrizeGraph=','AnnealGraph=',&
-         &'UseCustomSeed=','UseRandomSeed=']
+         &'UseCustomSeed=','UseRandomSeed=','RescaleRestartVelocities=']
     logical :: valvector_log(nkey_log) = (/&
          &.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false., &
          &.false.,.True.,.false.,.false.,.true.,.false.,.false.,.false.,.false.,.false.,&
-         &.false.,.false./)
+         &.false.,.false.,.false./)
 
     !Start and stop characters
     character(len=50), parameter :: startstop(2) = [character(len=50) :: &
@@ -408,6 +411,7 @@ contains
     gpmdt%anneal_graph = valvector_log(19)
     gpmdt%usecustomseed = valvector_log(20)
     gpmdt%userandomseed = valvector_log(21)
+    gpmdt%rescale_restart_vel = valvector_log(22)
     
     if(gpmdt%applyv)then 
         gpmdt%voltagef = valvector_char(5)


### PR DESCRIPTION
Add RescaleRestartVelocities= option to gpmdk. 

When T, scale the velocities to match the InitialTemperature value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/qmd-progress/370)
<!-- Reviewable:end -->
